### PR TITLE
Don't symlink python3 into python on CentOS 7 and Amazon Linux 2

### DIFF
--- a/platforms/Linux/amazonlinux/2/swift-lang.spec
+++ b/platforms/Linux/amazonlinux/2/swift-lang.spec
@@ -126,9 +126,6 @@ mv Yams-%{yams_version} yams
 # Adjust python version hwasan_symbolize
 %patch1 -p1
 
-# Fix python to python3
-ln -s /usr/bin/python3 /usr/bin/python
-
 %build
 export VERBOSE=1
 

--- a/platforms/Linux/centos/7/swift-lang.spec
+++ b/platforms/Linux/centos/7/swift-lang.spec
@@ -127,9 +127,6 @@ mv Yams-%{yams_version} yams
 # Adjust python version hwasan_symbolize
 %patch1 -p1
 
-# Fix python to python3
-ln -s /usr/bin/python3 /usr/bin/python
-
 %build
 export VERBOSE=1
 


### PR DESCRIPTION
```
+ ln -s /usr/bin/python3 /usr/bin/python
ln: failed to create symbolic link '/usr/bin/python': File exists
error: Bad exit status from /var/tmp/rpm-tmp.mam2Bm (%prep)
```