### PR TITLE
WiX: adjust some product description strings (NFC)

### DIFF
--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -4,11 +4,11 @@
   <String Id="Cli_ProductName" Value="Swift Command Line Tools" />
   <String Id="Dbg_ProductName" Value="Swift Debugging Tools" />
   <String Id="Ide_ProductName" Value="Swift IDE Integration Tools" />
-  <String Id="Runtime_ProductName_arm64" Value="Swift Utilities Windows (ARM64)" />
-  <String Id="Runtime_ProductName_x64" Value="Swift Utilities Windows (AMD64)" />
-  <String Id="Runtime_ProductName_x86" Value="Swift Utilities Windows (x86)" />
+  <String Id="Runtime_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
+  <String Id="Runtime_ProductName_x64" Value="Swift Windows Utilities (AMD64)" />
+  <String Id="Runtime_ProductName_x86" Value="Swift Windows Utilities (x86)" />
   <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_x64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (x86)" />
-  <String Id="BundleName" Value="Swift Software Development Kit" />
+  <String Id="BundleName" Value="Swift Tool Kit" />
 </WixLocalization>


### PR DESCRIPTION
This renames the bundle to the "Swift Tool Kit" (Software Development Kit is the expansion of SDK and results in the Swift SDK SDK). Additionally, rename the extra utilities (`plutil`) which is optional.