### PR TITLE
WiX: handle all installed architectures similarly

### DIFF
--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -6,8 +6,9 @@
     <VCRedistDownloadUrl Condition=" '$(VCRedistDownloadUrl)' == '' AND '$(VSMajorVersion)' != '' ">https://aka.ms/vs/$(VSMajorVersion)/release/vc_redist.$(ProductArchitecture).exe</VCRedistDownloadUrl>
     <DefineConstants>
       $(DefineConstants);
-      INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
+      INCLUDE_AMD64_SDK=$(INCLUDE_AMD64_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
+      INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       ANDROID_INCLUDE_ARM64_SDK=$(ANDROID_INCLUDE_ARM64_SDK);
       ANDROID_INCLUDE_x86_64_SDK=$(ANDROID_INCLUDE_x86_64_SDK);
       ANDROID_INCLUDE_ARM_SDK=$(ANDROID_INCLUDE_ARM_SDK);
@@ -25,15 +26,18 @@
     <ProjectReference Include="..\dbg\dbg.wixproj" BindName="dbg" />
     <ProjectReference Include="..\ide\ide.wixproj" BindName="ide" />
     <ProjectReference Include="..\rtl\msi\rtlmsi.wixproj" BindName="rtl" />
-    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=amd64;Platform=x86" BindName="sdk_amd64" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_X86_SDK)' != '' ">
-    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=x86;Platform=x86" BindName="sdk_x86" />
+  <ItemGroup Condition=" '$(INCLUDE_AMD64_SDK)' != '' ">
+    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=amd64;Platform=x86" BindName="sdk_amd64" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(INCLUDE_ARM64_SDK)' != '' ">
     <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=arm64;Platform=x86" BindName="sdk_arm64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(INCLUDE_X86_SDK)' != '' ">
+    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=x86;Platform=x86" BindName="sdk_x86" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(ANDROID_INCLUDE_ARM64_SDK)' != '' ">

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -98,23 +98,15 @@
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
       </MsiPackage>
 
-      <?if $(INCLUDE_X86_SDK) == true?>
+      <?if $(INCLUDE_AMD64_SDK) == true ?>
         <MsiPackage
-          SourceFile="!(bindpath.sdk_x86)\sdk.x86.msi"
-          InstallCondition="OptionsInstallSdkX86 = 1"
+          SourceFile="!(bindpath.sdk_amd64)\sdk.amd64.msi"
+          InstallCondition="OptionsInstallSdkAMD64 = 1"
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistX86]" />
+          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistAMD64]" />
         </MsiPackage>
       <?endif?>
-
-      <MsiPackage
-        SourceFile="!(bindpath.sdk_amd64)\sdk.amd64.msi"
-        InstallCondition="OptionsInstallSdkAMD64 = 1"
-        DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
-        <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-        <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistAMD64]" />
-      </MsiPackage>
 
       <?if $(INCLUDE_ARM64_SDK) == true ?>
         <MsiPackage
@@ -123,6 +115,16 @@
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
           <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistArm64]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_X86_SDK) == true?>
+        <MsiPackage
+          SourceFile="!(bindpath.sdk_x86)\sdk.x86.msi"
+          InstallCondition="OptionsInstallSdkX86 = 1"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistx86]" />
         </MsiPackage>
       <?endif?>
 


### PR DESCRIPTION
Treat all architectures equally and provide an option for all of them. This allows us to programmatically invoke the build target with the correct set of flags.