### PR TITLE
[6.0][Windows] Add _CompilerSwiftSyntax libs and plugin servers

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -365,6 +365,42 @@
       </Component>
     </ComponentGroup>
 
+   <ComponentGroup Id="compiler_swift_syntax" Directory="_usr_bin">
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftBasicFormat.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftCompilerPluginMessageHandling.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftDiagnostics.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftIDEUtils.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftOperators.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftParser.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftParserDiagnostics.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftSyntax.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftSyntaxBuilder.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftSyntaxMacroExpansion.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftSyntaxMacros.dll" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="swift_syntax" Directory="_usr_bin">
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftBasicFormat.dll" />
@@ -377,6 +413,9 @@
       </Component>
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftIDEUtils.dll" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftLibraryPluginProvider.dll" />
       </Component>
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftOperators.dll" />
@@ -404,6 +443,15 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="plugin_server" Directory="_usr_bin">
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-plugin-server.exe" />
+      </Component>
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftInProcPluginServer.dll" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="EnvironmentVariables">
       <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
         <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[_usr_bin]" />
@@ -423,7 +471,9 @@
       <ComponentGroupRef Id="argument_parser" />
       <ComponentGroupRef Id="tools_support_core" />
       <ComponentGroupRef Id="swift_driver" />
+      <ComponentGroupRef Id="compiler_swift_syntax" />
       <ComponentGroupRef Id="swift_syntax" />
+      <ComponentGroupRef Id="plugin_server" />
       <ComponentGroupRef Id="SwiftMacros" />
 
       <ComponentGroupRef Id="ClangResources" />


### PR DESCRIPTION
Cherry-pick #304 into `release/6.0`

(copied from https://github.com/swiftlang/swift/pull/74740)
* **Explanation**: swift-syntax libraries in compiler has been complied with `-enable-library-evolution` because the toolchain provides them as a public interface for building plugins (i.e. `lib/swift/host/*.swiftmodule`). But that was not great for the performance in the compiler. This PR changes that by separating swift-syntax libs for the compiler from the one for the plugins. So the compiler and the plugin now can use different version/ABI of swift-syntax libraries from the compiler. Now swift-syntax for the compiler are compiled without library evolution.
* **Scope**: Macro plugins
* **Risk**: Mid. This changes the mechanism of in-process plugins significantly. Now in-process plugins are communicate with the compiler using the same messaging serialization with other plugins (i.e. `swift-plugin-server`, and other executable plugins), instead of directly calling the `Macro.Type` expansion method. Also, to separate the swift-syntax libraries, this introduces another set of shared swift-syntax libraries in the toolchain.
* **Testing**: Passes current test suite.
* **Issue**: rdar://130532628
* **Reviewer**: Hamish Knight (@hamishknight) Alex Hoppen (@ahoppen) Ben Barham (@bnbarham)