### PR TITLE
WiX: package up Android auxiliary files

### DIFF
--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -512,6 +512,12 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="AuxiliaryFiles" Directory="AndroidSDK_usr_share">
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\share\posix_filesystem.apinotes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Configuration">
       <Component Directory="AndroidSDK">
         <File Source="$(SDK_ROOT)\SDKSettings.plist" />
@@ -551,6 +557,7 @@
       <ComponentGroupRef Id="apinotes" />
       <ComponentGroupRef Id="libcxxshim" />
       <ComponentGroupRef Id="Registrar" />
+      <ComponentGroupRef Id="AuxiliaryFiles" />
       <ComponentGroupRef Id="Configuration" />
       <ComponentGroupRef Id="SwiftShims" />
 


### PR DESCRIPTION
With the introduction of APINotes to workaround issues in the Bionic headers, we need to package up the additional content. Add the APINotes so that we can build swift-foundation.