### PR TITLE
WiX: add `InternalCollectionsUtilities` to the distribution

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -118,6 +118,9 @@
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" />
       </Component>
       <Component>
+        <File Source="$(DEVTOOLS_ROOT)\usr\bin\InternalCollectionsUtilities.dll" />
+      </Component>
+      <Component>
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" />
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
This is required with recent changes to SPM. Add the missing library to the toolchain distribution.

Fixes: #318