### PR TITLE
[swift 6][windows] installer script: add new foundation ICU headers to SDKs

### DIFF
--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -348,6 +348,9 @@
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\formattedvalue.h" />
       </Component>
       <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\formattednumber.h" />
+      </Component>
+      <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\fpositer.h" />
       </Component>
       <Component>
@@ -481,6 +484,9 @@
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\simpleformatter.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\simplenumberformatter.h" />
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\simpletz.h" />
@@ -654,6 +660,9 @@
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\uformattedvalue.h" />
       </Component>
       <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\uformattednumber.h" />
+      </Component>
+      <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\ugender.h" />
       </Component>
       <Component>
@@ -670,6 +679,12 @@
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\uloc.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\ulocale.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\ulocbuilder.h" />
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\ulocdata.h" />
@@ -715,6 +730,9 @@
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\unumberformatter.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\unumberoptions.h" />
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\unumberrangeformatter.h" />
@@ -766,6 +784,9 @@
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\ushape.h" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\usimplenumberformatter.h" />
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\_foundation_unicode\uspoof.h" />


### PR DESCRIPTION
This is needed after https://github.com/apple/swift-foundation-icu/pull/39

Explanation: After https://github.com/apple/swift-foundation-icu/pull/39 landed in foundation-icu, foundation-icu's modulemap started to depend on new headers from that PR. They need to be installed by the windows SDK installer in order for the modulemap to be valid in the windows toolchain distribution for Swift.
Scope: windows SDK installer
Risk: Low
Testing: toolchain build, and build of windows toolchain in a github workflow
Reviewer: @compnerd
Main branch PR: https://github.com/swiftlang/swift-installer-scripts/pull/321