### PR TITLE
[windows] add _CompilerSwiftIfConfig dependency to the swift-syntax i…

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -388,6 +388,9 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftIDEUtils.dll" />
       </Component>
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftIfConfig.dll" />
+      </Component>
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\_CompilerSwiftOperators.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
…nstaller step

https://github.com/swiftlang/swift/pull/75014 added the new dependency, that the swift compiler depends on, and thus we need to make sure that this DLL is installed