### PR TITLE
WiX: add Foundation macros to the build tools

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -326,6 +326,12 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="FoundationMacros" Directory="_usr_bin">
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\FoundationMacros.dll" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="argument_parser" Directory="_usr_bin">
       <Component>
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" />
@@ -425,6 +431,7 @@
       <ComponentGroupRef Id="swift_driver" />
       <ComponentGroupRef Id="swift_syntax" />
       <ComponentGroupRef Id="SwiftMacros" />
+      <ComponentGroupRef Id="FoundationMacros" />
 
       <ComponentGroupRef Id="ClangResources" />
 


### PR DESCRIPTION
Include a prebuilt copy of the Foundation macros in the toolchain distribution on Windows to match the desired behaviour.