### PR TITLE
WiX: include `llvm-ml` in the build tools

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -101,6 +101,9 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\llvm-lipo.exe" />
       </Component>
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\llvm-ml.exe" />
+      </Component>
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\llvm-mt.exe" />
       </Component>
       <Component>


### PR DESCRIPTION
The Windows build tools should include `llvm-ml`, a replacement for `ml` which is the assembler.