### PR TITLE
WiX: extract Testing Macros into a component (NFC)

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -336,14 +336,17 @@
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftMacros.dll" />
       </Component>
-      <Component>
-        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\TestingMacros.dll" />
-      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="FoundationMacros" Directory="_usr_bin">
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\FoundationMacros.dll" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="TestingMacros" Directory="_usr_bin">
+      <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\TestingMacros.dll" />
       </Component>
     </ComponentGroup>
 
@@ -500,6 +503,7 @@
       <ComponentGroupRef Id="plugin_server" />
       <ComponentGroupRef Id="SwiftMacros" />
       <ComponentGroupRef Id="FoundationMacros" />
+      <ComponentGroupRef Id="TestingMacros" />
 
       <ComponentGroupRef Id="ClangResources" />
 


### PR DESCRIPTION
Extract the testing macros into their own component group. Each repository is currently setup into a single component group that we then enumerate into the install image. This follows suit for the testing macros.