### PR TITLE
[android] optionally include DS2 in Android SDK

### DIFF
--- a/platforms/Windows/android_sdk/android_sdk.wixproj
+++ b/platforms/Windows/android_sdk/android_sdk.wixproj
@@ -7,6 +7,7 @@
 
     <DefineConstants>
       $(DefineConstants);
+      ANDROID_INCLUDE_DS2=$(ANDROID_INCLUDE_DS2);
       SwiftShimsPath=$(SwiftShimsPath);
     </DefineConstants>
   </PropertyGroup>

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -5,18 +5,31 @@
     <?define ArchName = "arm64"?>
     <?define ArchArchDir = "aarch64"?>
     <?define ArchTriple = "aarch64-unknown-linux-android"?>
+    <?define ArchTripleDir = "aarch64-unknown-linux-android"?>
   <?elseif $(ProductArchitecture) = "x86_64"?>
     <?define ArchName = "amd64"?>
     <?define ArchArchDir = "x86_64"?>
     <?define ArchTriple = "x86_64-unknown-linux-android"?>
+    <?define ArchTripleDir = "x86_64-unknown-linux-android"?>
   <?elseif $(ProductArchitecture) = "armv7"?>
     <?define ArchName = "arm"?>
     <?define ArchArchDir = "armv7"?>
+    <!--
+      The Swift compiler outputs Android armv7 .swiftdoc, .swiftmodule, and
+      .swiftinterface files with the name armv7-unknown-linux-android. Since the
+      correct triple is armv7-unknown-linux-androideabi, define two constants to
+      deal with the inconsistency.
+
+      TODO: consider updating Swift compiler to output file names matching the
+      correct triple.
+    -->
     <?define ArchTriple = "armv7-unknown-linux-android"?>
+    <?define ArchTripleDir = "armv7-unknown-linux-androideabi"?>
   <?elseif $(ProductArchitecture) = "i686"?>
     <?define ArchName = "x86"?>
     <?define ArchArchDir = "i686"?>
     <?define ArchTriple = "i686-unknown-linux-android"?>
+    <?define ArchTripleDir = "i686-unknown-linux-android"?>
   <?endif?>
 
   <Package
@@ -79,7 +92,7 @@
                 </Directory>
               </Directory>
             </Directory>
-            <Directory Name="$(ArchTriple)">
+            <Directory Name="$(ArchTripleDir)">
               <Directory Id="Android_Library_ARCH_bin" Name="bin" />
             </Directory>
           </Directory>
@@ -162,7 +175,7 @@
     <ComponentGroup Id="DS2">
       <?if $(ANDROID_INCLUDE_DS2) == true ?>
         <Component Directory="Android_Library_ARCH_bin">
-          <File Source="$(PLATFORM_ROOT)\Developer\Library\$(ArchTriple)\bin\ds2" />
+          <File Source="$(PLATFORM_ROOT)\Developer\Library\$(ArchTripleDir)\bin\ds2" />
         </Component>
       <?endif?>
     </ComponentGroup>

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -79,6 +79,9 @@
                 </Directory>
               </Directory>
             </Directory>
+            <Directory Name="$(ArchTriple)">
+              <Directory Id="Android_Library_ARCH_bin" Name="bin" />
+            </Directory>
           </Directory>
           <Directory Name="SDKs">
             <!-- Android.sdk -->
@@ -154,6 +157,14 @@
       <Component Directory="Testing.swiftmodule">
         <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\android\Testing.swiftmodule\$(ArchTriple).swiftmodule" />
       </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="DS2">
+      <?if $(ANDROID_INCLUDE_DS2) == true ?>
+        <Component Directory="Android_Library_ARCH_bin">
+          <File Source="$(PLATFORM_ROOT)\Developer\Library\$(ArchTriple)\bin\ds2" />
+        </Component>
+      <?endif?>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftRemoteMirror" Directory="AndroidSDK_usr_include_swift_SwiftRemoteMirror">
@@ -1283,6 +1294,7 @@
       <ComponentGroupRef Id="Registrar" />
       <ComponentGroupRef Id="Configuration" />
       <ComponentGroupRef Id="SwiftShims" />
+      <ComponentGroupRef Id="DS2" />
 
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>


### PR DESCRIPTION
Conditionally include DS2 in the Android SDK when building the MSI with `-p:ANDROID_INCLUDE_DS2=true` passed to `msbuild`. Has no impact on the generated installer if this property is not set.

Related to the `build.ps1` changes in https://github.com/swiftlang/swift/pull/76113

## Validation
Verified by manually invoking `msbuild` against locally built swift toolchain (with local changes to build DS2) with and without `-p:ANDROID_INCLUDE_DS2=true` and manually inspected the output MSI file with MSI Viewer. Done for aarch64, x86_64, i686, and armv7.
```
MSBuild.exe -nologo -restore -maxCpuCount -p:BaseOutputPath=S:\b\installer\ -p:Configuration=Release -p:SignOutput=false -p:PLATFORM_ROOT="S:\b\arm64\Android.platform" -p:SDK_ROOT="S:\b\arm64\Android.platform\Developer\SDKs\Android.sdk" -p:ProductVersion=0.0.0 -p:ProductArchitecture=aarch64 -p:ANDROID_INCLUDE_DS2=true "S:\SourceCache\swift-installer-scripts\platforms\Windows\android_sdk\android_sdk.wixproj"
MSBuild.exe -nologo -restore -maxCpuCount -p:BaseOutputPath=S:\b\installer\ -p:Configuration=Release -p:SignOutput=false -p:PLATFORM_ROOT="S:\b\x64\Android.platform" -p:SDK_ROOT="S:\b\x64\Android.platform\Developer\SDKs\Android.sdk" -p:ProductVersion=0.0.0 -p:ProductArchitecture=x86_64 -p:ANDROID_INCLUDE_DS2=true "S:\SourceCache\swift-installer-scripts\platforms\Windows\android_sdk\android_sdk.wixproj"
MSBuild.exe -nologo -restore -maxCpuCount -p:BaseOutputPath=S:\b\installer\ -p:Configuration=Release -p:SignOutput=false -p:PLATFORM_ROOT="S:\b\armv7\Android.platform" -p:SDK_ROOT="S:\b\armv7\Android.platform\Developer\SDKs\Android.sdk" -p:ProductVersion=0.0.0 -p:ProductArchitecture=armv7 -p:ANDROID_INCLUDE_DS2=true "S:\SourceCache\swift-installer-scripts\platforms\Windows\android_sdk\android_sdk.wixproj"
MSBuild.exe -nologo -restore -maxCpuCount -p:BaseOutputPath=S:\b\installer\ -p:Configuration=Release -p:SignOutput=false -p:PLATFORM_ROOT="S:\b\x86\Android.platform" -p:SDK_ROOT="S:\b\x86\Android.platform\Developer\SDKs\Android.sdk" -p:ProductVersion=0.0.0 -p:ProductArchitecture=i686 -p:ANDROID_INCLUDE_DS2=true "S:\SourceCache\swift-installer-scripts\platforms\Windows\android_sdk\android_sdk.wixproj"
```