### PR TITLE
[windows] add usr/lib/swift/clang to the toolchain installer

### DIFF
--- a/platforms/Windows/bld/bld.wixproj
+++ b/platforms/Windows/bld/bld.wixproj
@@ -5,6 +5,7 @@
       DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
       TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;
+      TOOLCHAIN_ROOT_USR_LIB_SWIFT_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\swift\clang;
     </DefineConstants>
   </PropertyGroup>
 
@@ -17,6 +18,17 @@
       <ComponentGroupName>ClangResources</ComponentGroupName>
       <DirectoryRefId>_usr_lib_clang</DirectoryRefId>
       <PreprocessorVariable>var.TOOLCHAIN_ROOT_USR_LIB_CLANG</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
+
+  <ItemGroup>
+    <HarvestDirectory Include="$(TOOLCHAIN_ROOT)\usr\lib\swift\clang">
+      <ComponentGroupName>SwiftClangResources</ComponentGroupName>
+      <DirectoryRefId>_usr_lib_swift_clang</DirectoryRefId>
+      <PreprocessorVariable>var.TOOLCHAIN_ROOT_USR_LIB_SWIFT_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>
       <SuppressRootDirectory>true</SuppressRootDirectory>

--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -506,6 +506,7 @@
       <ComponentGroupRef Id="TestingMacros" />
 
       <ComponentGroupRef Id="ClangResources" />
+      <ComponentGroupRef Id="SwiftClangResources" />
 
       <ComponentGroupRef Id="EnvironmentVariables" />
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -44,7 +44,9 @@
               <Directory Id="_usr_include" Name="include" />
               <Directory Id="_usr_lib" Name="lib">
                 <Directory Id="_usr_lib_clang" Name="clang" />
-                <Directory Id="_usr_lib_swift" Name="swift" />
+                <Directory Id="_usr_lib_swift" Name="swift">
+                  <Directory Id="_usr_lib_swift_clang" Name="clang" />
+                </Directory>
               </Directory>
               <Directory Id="_usr_share" Name="share">
                 <Directory Id="_usr_share_docc" Name="docc">


### PR DESCRIPTION
this directory contains clang's resource headers that are needed by the clang embedded inside of the swift compiler, as it assumes its clang resources are in usr/lib/swift/clang, as opposed to standalone clang looking in usr/lib/clang/<clang_version>