### PR TITLE
WiX: optionalise `plutil` through a hidden option

### DIFF
--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -32,6 +32,7 @@
     <Variable Name="OptionsInstallDbg" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallIde" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallRtl" Value="1" />
+    <Variable Name="OptionsInstallUtl" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallSdkX86" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallRedistX86" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallSdkAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
@@ -67,6 +68,7 @@
         SourceFile="!(bindpath.rtl)\rtl.msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        <MsiProperty Name="InstallUtilities" Value="[OptionsInstallUtl]" />
       </MsiPackage>
 
       <MsiPackage

--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -60,7 +60,7 @@
             <Checkbox Name="OptionsInstallCli" X="176" Y="159" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallDbg" X="176" Y="177" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallIde" X="176" Y="195" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallRtl" X="176" Y="213" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Rtl_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallRtl" X="176" Y="213" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Rtl_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallSdkAMD64" X="176" Y="231" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_amd64)</Checkbox>
             <Checkbox Name="OptionsInstallRedistAMD64" X="194" Y="249" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkAMD64">#(loc.Redist_amd64)</Checkbox>
             <Checkbox Name="OptionsInstallSdkArm64" X="176" Y="267" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_arm64)</Checkbox>

--- a/platforms/Windows/rtl/lib/rtllib.wxs
+++ b/platforms/Windows/rtl/lib/rtllib.wxs
@@ -105,6 +105,9 @@
       <ComponentGroupRef Id="BlocksRuntime_$(ProductArchitecture)" />
       <ComponentGroupRef Id="libdispatch_$(ProductArchitecture)" />
       <ComponentGroupRef Id="Foundation_$(ProductArchitecture)" />
+    </ComponentGroup>
+
+    <ComponentGroup Id="swift_runtime_utilities_$(ProductArchitecture)">
       <ComponentGroupRef Id="plutil_$(ProductArchitecture)" />
     </ComponentGroup>
   </Fragment>

--- a/platforms/Windows/rtl/msi/rtlmsi.wxs
+++ b/platforms/Windows/rtl/msi/rtlmsi.wxs
@@ -31,5 +31,10 @@
       <ComponentGroupRef Id="EnvironmentVariables" />
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
+
+    <Feature Id="SwiftRuntimeUtilities" AllowAbsent="yes" Title="!(loc.Utl_ProductName_$(ProductArchitecture))">
+      <Level Condition="INSTALLUTILITIES = 0" Value="0" />
+      <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />
+    </Feature>
   </Package>
 </Wix>

--- a/platforms/Windows/rtl/msm/rtlmsm.wxs
+++ b/platforms/Windows/rtl/msm/rtlmsm.wxs
@@ -15,5 +15,6 @@
     Version="$(NonSemVerProductVersion)">
 
     <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />
+    <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />
   </Module>
 </Wix>

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -6,16 +6,19 @@
   <String Id="Cli_ProductName" Value="Swift Command Line Tools" />
   <String Id="Dbg_ProductName" Value="Swift Debugging Tools" />
   <String Id="Ide_ProductName" Value="Swift IDE Integration Tools" />
-  <String Id="Rtl_ProductName" Value="Swift Windows Utilities" />
+  <String Id="Rtl_ProductName" Value="Swift Windows Runtime" />
   <String Id="VCRuntime_ProductName_arm64" Value="Visual C++ Runtime (ARM64)" />
   <String Id="VCRuntime_ProductName_amd64" Value="Visual C++ Runtime (AMD64)" />
   <String Id="VCRuntime_ProductName_x86" Value="Visual C++ Runtime (X86)" />
-  <String Id="Rtl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
-  <String Id="Rtl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
-  <String Id="Rtl_ProductName_x86" Value="Swift Windows Utilities (X86)" />
+  <String Id="Rtl_ProductName_arm64" Value="Swift Windows Runtime (ARM64)" />
+  <String Id="Rtl_ProductName_amd64" Value="Swift Windows Runtime (AMD64)" />
+  <String Id="Rtl_ProductName_x86" Value="Swift Windows Runtime (X86)" />
   <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
+  <String Id="Utl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
+  <String Id="Utl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
+  <String Id="Utl_ProductName_x86" Value="Swift Windows Utilities (X86)" />
   <String Id="Android_Sdk_arm64" Value="Swift Android SDK (ARM64)" />
   <String Id="Android_Sdk_amd64" Value="Swift Android SDK (AMD64)" />
   <String Id="Android_Sdk_arm" Value="Swift Android SDK (ARM)" />


### PR DESCRIPTION
Add an option to elide `plutil` from installation. This is a tiny binary that is useful, but distributions may wish to remove it. Adjust the installer labels and also force install the runtime now that the compiler depends on it.

Fixes: #340 