### PR TITLE
Remove SwiftFormat.dll from Windows installer script

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -249,9 +249,6 @@
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-format.exe" />
       </Component>
-      <Component>
-        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftFormat.dll" />
-      </Component>
     </ComponentGroup>
 
     <Feature Id="CLITools" AllowAbsent="no" Title="!(loc.Cli_ProductName)">


### PR DESCRIPTION
SwiftFormat.dll no longer exists after https://github.com/swiftlang/swift/pull/76900.