### PR TITLE
[cxx-interop] Include swiftinterface files for Cxx and CxxStdlib

### DIFF
--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -301,6 +301,9 @@
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(ArchTriple).swiftdoc" />
       </Component>
       <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(ArchTriple).swiftinterface" />
+      </Component>
+      <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(ArchTriple).swiftmodule" />
       </Component>
       <Component Directory="WindowsSDK_usr_lib_swift_windows_ARCH">
@@ -311,6 +314,9 @@
     <ComponentGroup Id="CxxStdlib" Directory="CxxStdlib.swiftmodule">
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\$(ArchTriple).swiftdoc" />
+      </Component>
+      <Component>
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\$(ArchTriple).swiftinterface" />
       </Component>
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\$(ArchTriple).swiftmodule" />


### PR DESCRIPTION
These two libraries are now built with library evolution enabled.

See https://github.com/swiftlang/swift/pull/77559