### PR TITLE
WiX: adjust packaging for DocC

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -240,7 +240,14 @@
     <ComponentGroup Id="DocC" Directory="_usr_bin">
       <?if $(INCLUDE_SWIFT_DOCC) == true ?>
         <Component>
-          <File Source="$(SWIFT_DOCC_BUILD)\docc.exe" />
+          <File Source="$(TOOLCHAIN_ROOT)\usr\bin\docc.exe" />
+        </Component>
+        <Component>
+          <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftDocC.dll" />
+        </Component>
+
+        <Component Directory="_usr_lib">
+          <File Source="$(TOOLCHAIN_ROOT)\usr\lib\SwiftDocC.lib" />
         </Component>
       <?endif?>
     </ComponentGroup>


### PR DESCRIPTION
In order to prepare for DocC being consumed by SourceKit-LSP, we are building SwiftDocC as a shared library and docc links against it. Adjust the packaging rules accordingly.