### PR TITLE
WiX: remove references to `DEVTOOLS_ROOT`

### DIFF
--- a/platforms/Windows/bld/bld.wixproj
+++ b/platforms/Windows/bld/bld.wixproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);
-      DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
       TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;
       TOOLCHAIN_ROOT_USR_LIB_SWIFT_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\swift\clang;

--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -352,40 +352,40 @@
 
     <ComponentGroup Id="argument_parser" Directory="_usr_bin">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\ArgumentParser.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\ArgumentParser.dll" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="tools_support_core" Directory="_usr_bin">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\TSCBasic.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\TSCBasic.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\TSCUtility.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\TSCUtility.dll" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="swift_driver" Directory="_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to swift.exe instead? -->
       <Component>
-        <File Name="swiftc.exe" Source="$(DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" />
+        <File Name="swiftc.exe" Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-driver.exe" />
       </Component>
 
       <Component>
-        <File Name="swift.exe" Source="$(DEVTOOLS_ROOT)\usr\bin\swift-driver.exe" />
+        <File Name="swift.exe" Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-driver.exe" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\swift-help.exe" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-help.exe" />
       </Component>
 
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\SwiftOptions.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftOptions.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\SwiftDriver.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftDriver.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\SwiftDriverExecution.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SwiftDriverExecution.dll" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/cli/cli.wixproj
+++ b/platforms/Windows/cli/cli.wixproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);
-      DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
       SWIFT_DOCC_BUILD=$(SWIFT_DOCC_BUILD);
       INCLUDE_SWIFT_DOCC=$(INCLUDE_SWIFT_DOCC);

--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -112,73 +112,73 @@
 
     <ComponentGroup Id="collections" Directory="_usr_bin">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\Collections.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\Collections.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\DequeModule.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\DequeModule.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\InternalCollectionsUtilities.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\InternalCollectionsUtilities.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\OrderedCollections.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\OrderedCollections.dll" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="llbuild" Directory="_usr_bin">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\llbuildSwift.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\llbuildSwift.dll" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="system" Directory="_usr_bin">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\SystemPackage.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SystemPackage.dll" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="CompilerPluginSupport" Directory="_usr_lib_swift_pm_ManifestAPI">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.lib" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.lib" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftdoc" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftdoc" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftmodule" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.swiftmodule" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="PackageDescription" Directory="_usr_lib_swift_pm_ManifestAPI">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.lib" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftdoc" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\PackageDescription.swiftmodule" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="PackagePlugin" Directory="_usr_lib_swift_pm_PluginAPI">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.lib" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.lib" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftdoc" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftdoc" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftmodule" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\PluginAPI\PackagePlugin.swiftmodule" />
       </Component>
     </ComponentGroup>
 
@@ -188,50 +188,50 @@
       <ComponentGroupRef Id="PackagePlugin" />
 
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\swift-build.exe" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-build.exe" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\swift-package.exe" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-package.exe" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\swift-run.exe" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-run.exe" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\swift-test.exe" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-test.exe" />
       </Component>
 
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\Basics.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\Basics.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\Build.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\Build.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\Commands.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\Commands.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\CoreCommands.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\CoreCommands.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\DriverSupport.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\DriverSupport.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageGraph.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\PackageGraph.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageLoading.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\PackageLoading.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageModel.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\PackageModel.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageModelSyntax.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\PackageModelSyntax.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SPMBuildCore.dll" />
       </Component>
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\Workspace.dll" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\Workspace.dll" />
       </Component>
 
       <!-- FIXME(compnerd) we should include the SPM import libraries -->

--- a/platforms/Windows/dbg/dbg.wixproj
+++ b/platforms/Windows/dbg/dbg.wixproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);
-      DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
       SWIFT_INSPECT_BUILD=$(SWIFT_INSPECT_BUILD);
       INCLUDE_SWIFT_INSPECT=$(INCLUDE_SWIFT_INSPECT);

--- a/platforms/Windows/ide/ide.wixproj
+++ b/platforms/Windows/ide/ide.wixproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);
-      DEVTOOLS_ROOT=$(DEVTOOLS_ROOT);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT)
     </DefineConstants>
   </PropertyGroup>

--- a/platforms/Windows/ide/ide.wxs
+++ b/platforms/Windows/ide/ide.wxs
@@ -44,7 +44,7 @@
 
     <ComponentGroup Id="lsp" Directory="_usr_bin">
       <Component>
-        <File Source="$(DEVTOOLS_ROOT)\usr\bin\sourcekit-lsp.exe" />
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\sourcekit-lsp.exe" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -165,7 +165,6 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.
   -p:BaseReleaseDownloadUrl=todo://base/release/download/url ^
   -p:Configuration=Release ^
   -p:BaseOutputPath=%PackageRoot%\online\ ^
-  -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:PLATFORM_ROOT_X86=path\to\x86\platform ^
   -p:PLATFORM_ROOT_AMD64=path\to\amd64\platform ^


### PR DESCRIPTION
As the Windows build has evolved, we have built up a complete toolchain image and removed the need for the separate `DEVTOOLS_ROOT`. This simplifies the packaging manifest and associated MSBuild files.