### PR TITLE
WiX: adjust SDK handling for homogeneity

### DIFF
--- a/platforms/Windows/android_sdk/android_sdk.wixproj
+++ b/platforms/Windows/android_sdk/android_sdk.wixproj
@@ -1,6 +1,6 @@
 <Project Sdk="WixToolset.Sdk/4.0.5">
   <PropertyGroup>
-    <OutputName>android_sdk.$(ProductArchitecture)</OutputName>
+    <OutputName>sdk.android.$(ProductArchitecture)</OutputName>
     <Platform>x86</Platform>
 
     <SwiftShimsPath>$(SDK_ROOT)\usr\lib\swift\shims</SwiftShimsPath>

--- a/platforms/Windows/android_sdk/android_sdk.wxs
+++ b/platforms/Windows/android_sdk/android_sdk.wxs
@@ -40,7 +40,7 @@
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
-    <Media Id="1" Cabinet="android_sdk.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+    <Media Id="1" Cabinet="sdk.android.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
 
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(AndroidSDKUpgradeCode)" />
 

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -6,13 +6,13 @@
     <VCRedistDownloadUrl Condition=" '$(VCRedistDownloadUrl)' == '' AND '$(VSMajorVersion)' != '' ">https://aka.ms/vs/$(VSMajorVersion)/release/vc_redist.$(ProductArchitecture).exe</VCRedistDownloadUrl>
     <DefineConstants>
       $(DefineConstants);
-      INCLUDE_AMD64_SDK=$(INCLUDE_AMD64_SDK);
-      INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
-      INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
-      ANDROID_INCLUDE_ARM64_SDK=$(ANDROID_INCLUDE_ARM64_SDK);
-      ANDROID_INCLUDE_x86_64_SDK=$(ANDROID_INCLUDE_x86_64_SDK);
-      ANDROID_INCLUDE_ARM_SDK=$(ANDROID_INCLUDE_ARM_SDK);
-      ANDROID_INCLUDE_X86_SDK=$(ANDROID_INCLUDE_X86_SDK);
+      INCLUDE_ANDROID_ARM_SDK=$(INCLUDE_ANDROID_ARM_SDK);
+      INCLUDE_ANDROID_ARM64_SDK=$(INCLUDE_ANDROID_ARM64_SDK);
+      INCLUDE_ANDROID_X86_SDK=$(INCLUDE_ANDROID_X86_SDK);
+      INCLUDE_ANDROID_X86_64_SDK=$(INCLUDE_ANDROID_X86_64_SDK);
+      INCLUDE_WINDOWS_AMD64_SDK=$(INCLUDE_WINDOWS_AMD64_SDK);
+      INCLUDE_WINDOWS_ARM64_SDK=$(INCLUDE_WINDOWS_ARM64_SDK);
+      INCLUDE_WINDOWS_X86_SDK=$(INCLUDE_WINDOWS_X86_SDK);
     </DefineConstants>
   </PropertyGroup>
 
@@ -28,31 +28,31 @@
     <ProjectReference Include="..\rtl\msi\rtlmsi.wixproj" BindName="rtl" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_AMD64_SDK)' != '' ">
-    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=amd64;Platform=x86" BindName="sdk_amd64" />
+  <ItemGroup Condition=" '$(INCLUDE_ANDROID_ARM_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=armv7;Platform=x86" BindName="android_armv7_sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_ARM64_SDK)' != '' ">
-    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=arm64;Platform=x86" BindName="sdk_arm64" />
+  <ItemGroup Condition=" '$(INCLUDE_ANDROID_ARM64_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=aarch64;Platform=x86" BindName="android_aarch64_sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(INCLUDE_X86_SDK)' != '' ">
-    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=x86;Platform=x86" BindName="sdk_x86" />
+  <ItemGroup Condition=" '$(INCLUDE_ANDROID_X86_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=i686;Platform=x86" BindName="android_i686_sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(ANDROID_INCLUDE_ARM64_SDK)' != '' ">
-    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=aarch64;Platform=x86" BindName="android_sdk_aarch64" />
+  <ItemGroup Condition=" '$(INCLUDE_ANDROID_x86_64_SDK)' != '' ">
+    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=x86_64;Platform=x86" BindName="android_x86_64_sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(ANDROID_INCLUDE_x86_64_SDK)' != '' ">
-    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=x86_64;Platform=x86" BindName="android_sdk_x86_64" />
+  <ItemGroup Condition=" '$(INCLUDE_WINDOWS_AMD64_SDK)' != '' ">
+    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=amd64;Platform=x86" BindName="windows_amd64_sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(ANDROID_INCLUDE_ARM_SDK)' != '' ">
-    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=armv7;Platform=x86" BindName="android_sdk_armv7" />
+  <ItemGroup Condition=" '$(INCLUDE_WINDOWS_ARM64_SDK)' != '' ">
+    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=arm64;Platform=x86" BindName="windows_arm64_sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(ANDROID_INCLUDE_X86_SDK)' != '' ">
-    <ProjectReference Include="..\android_sdk\android_sdk.wixproj" Properties="ProductArchitecture=i686;Platform=x86" BindName="android_sdk_i686" />
+  <ItemGroup Condition=" '$(INCLUDE_WINDOWS_X86_SDK)' != '' ">
+    <ProjectReference Include="..\sdk\sdk.wixproj" Properties="ProductArchitecture=x86;Platform=x86" BindName="windows_x86_sdk" />
   </ItemGroup>
 </Project>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -27,22 +27,28 @@
     -->
     <Variable Name="InstallRoot" bal:Overridable="yes" Type="formatted" Persisted="yes"
       Value="[LocalAppDataFolder]Programs\Swift" />
-    <Variable Name="OptionsInstallBld" Value="1" />
-    <Variable Name="OptionsInstallCli" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallDbg" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallIde" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallRtl" Value="1" />
-    <Variable Name="OptionsInstallUtl" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallSdkX86" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallRedistX86" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallSdkAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallRedistAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallSdkArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallRedistArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallAndroidSdkArm64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallAndroidSdkAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallAndroidSdkArm" bal:Overridable="yes" Persisted="yes" Value="0" />
-    <Variable Name="OptionsInstallAndroidSdkX86" bal:Overridable="yes" Persisted="yes" Value="0" />
+
+    <Variable Name="OptionsInstallBLD" Value="1" />
+    <Variable Name="OptionsInstallCLI" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallDBG" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallIDE" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallRTL" Value="1" />
+
+    <Variable Name="OptionsInstallUtilities" bal:Overridable="yes" Persisted="yes" Value="1" />
+
+    <Variable Name="OptionsInstallWindowsSDKX86" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallWindowsRedistX86" bal:Overridable="yes" Persisted="yes" Value="1" />
+
+    <Variable Name="OptionsInstallWindowsSDKAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallWindowsRedistAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
+
+    <Variable Name="OptionsInstallWindowsSDKARM64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallWindowsRedistARM64" bal:Overridable="yes" Persisted="yes" Value="1" />
+
+    <Variable Name="OptionsInstallAndroidSDKARM64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSDKAMD64" bal:Overridable="yes" Persisted="yes" Value="1" />
+    <Variable Name="OptionsInstallAndroidSDKARM" bal:Overridable="yes" Persisted="yes" Value="0" />
+    <Variable Name="OptionsInstallAndroidSDKX86" bal:Overridable="yes" Persisted="yes" Value="0" />
 
     <!--
     For the online bundle, we need to provide a download URL for each package and its .cabs.
@@ -68,7 +74,7 @@
         SourceFile="!(bindpath.rtl)\rtl.msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-        <MsiProperty Name="InstallUtilities" Value="[OptionsInstallUtl]" />
+        <MsiProperty Name="InstallUtilities" Value="[OptionsInstallUtilities]" />
       </MsiPackage>
 
       <MsiPackage
@@ -79,88 +85,88 @@
 
       <MsiPackage
         SourceFile="!(bindpath.cli)\cli.msi"
-        InstallCondition="OptionsInstallCli = 1"
+        InstallCondition="OptionsInstallCLI = 1"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
       </MsiPackage>
 
       <MsiPackage
         SourceFile="!(bindpath.dbg)\dbg.msi"
-        InstallCondition="OptionsInstallDbg = 1"
+        InstallCondition="OptionsInstallDBG = 1"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
       </MsiPackage>
 
       <MsiPackage
         SourceFile="!(bindpath.ide)\ide.msi"
-        InstallCondition="OptionsInstallIde = 1"
+        InstallCondition="OptionsInstallIDE = 1"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
       </MsiPackage>
 
-      <?if $(INCLUDE_AMD64_SDK) == true ?>
+      <?if $(INCLUDE_ANDROID_ARM_SDK) == true ?>
         <MsiPackage
-          SourceFile="!(bindpath.sdk_amd64)\sdk.amd64.msi"
-          InstallCondition="OptionsInstallSdkAMD64 = 1"
-          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
-          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistAMD64]" />
-        </MsiPackage>
-      <?endif?>
-
-      <?if $(INCLUDE_ARM64_SDK) == true ?>
-        <MsiPackage
-          SourceFile="!(bindpath.sdk_arm64)\sdk.arm64.msi"
-          InstallCondition="OptionsInstallSdkArm64 = 1"
-          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
-          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistArm64]" />
-        </MsiPackage>
-      <?endif?>
-
-      <?if $(INCLUDE_X86_SDK) == true?>
-        <MsiPackage
-          SourceFile="!(bindpath.sdk_x86)\sdk.x86.msi"
-          InstallCondition="OptionsInstallSdkX86 = 1"
-          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
-          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallRedistx86]" />
-        </MsiPackage>
-      <?endif?>
-
-      <?if $(ANDROID_INCLUDE_ARM64_SDK) == true ?>
-        <MsiPackage
-          SourceFile="!(bindpath.android_sdk_aarch64)\android_sdk.aarch64.msi"
-          InstallCondition="OptionsInstallAndroidSdkArm64 = 1"
+          SourceFile="!(bindpath.android_armv7_sdk)\sdk.android.armv7.msi"
+          InstallCondition="OptionsInstallAndroidSDKARM = 1"
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
         </MsiPackage>
       <?endif?>
 
-      <?if $(ANDROID_INCLUDE_x86_64_SDK) == true ?>
+      <?if $(INCLUDE_ANDROID_ARM64_SDK) == true ?>
         <MsiPackage
-          SourceFile="!(bindpath.android_sdk_x86_64)\android_sdk.x86_64.msi"
-          InstallCondition="OptionsInstallAndroidSdkAMD64 = 1"
+          SourceFile="!(bindpath.android_aarch64_sdk)\sdk.android.aarch64.msi"
+          InstallCondition="OptionsInstallAndroidSDKARM64 = 1"
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
         </MsiPackage>
       <?endif?>
 
-      <?if $(ANDROID_INCLUDE_ARM_SDK) == true ?>
+      <?if $(INCLUDE_ANDROID_X86_SDK) == true ?>
         <MsiPackage
-          SourceFile="!(bindpath.android_sdk_armv7)\android_sdk.armv7.msi"
-          InstallCondition="OptionsInstallAndroidSdkArm = 1"
+          SourceFile="!(bindpath.android_i686_sdk)\sdk.android.i686.msi"
+          InstallCondition="OptionsInstallAndroidSDKX86 = 1"
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
         </MsiPackage>
       <?endif?>
 
-      <?if $(ANDROID_INCLUDE_X86_SDK) == true ?>
+      <?if $(INCLUDE_ANDROID_X86_64_SDK) == true ?>
         <MsiPackage
-          SourceFile="!(bindpath.android_sdk_i686)\android_sdk.i686.msi"
-          InstallCondition="OptionsInstallAndroidSdkX86 = 1"
+          SourceFile="!(bindpath.android_x86_64_sdk)\sdk.android.x86_64.msi"
+          InstallCondition="OptionsInstallAndroidSDKAMD64 = 1"
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_WINDOWS_AMD64_SDK) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.windows_amd64_sdk)\sdk.windows.amd64.msi"
+          InstallCondition="OptionsInstallWindowsSDKAMD64 = 1"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallWindowsRedistAMD64]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_WINDOWS_ARM64_SDK) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.windows_arm64_sdk)\sdk.windows.arm64.msi"
+          InstallCondition="OptionsInstallWindowsSDKARM64 = 1"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallWindowsRedistARM64]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_WINDOWS_X86_SDK) == true?>
+        <MsiPackage
+          SourceFile="!(bindpath.windows_x86_sdk)\sdk.windows.x86.msi"
+          InstallCondition="OptionsInstallWindowsSDKX86 = 1"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+          <MsiProperty Name="INSTALLREDIST" Value="[OptionsInstallWindowsRedistX86]" />
         </MsiPackage>
       <?endif?>
      </Chain>

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -32,14 +32,20 @@ The bundle authoring (in `installer.wxs`) drives optional install directory and 
 | Variable | Description |
 | -------- | ----------- |
 | InstallRoot | A formatted string variable that specifies the installation root directory. The default value specified in `installer.wxs` should match the equivalent `INSTALLROOT` authoring in `shared.wxs`. The bundle variable is passed to each `MsiPackage` so overwrites the default directory authored in the MSI packages -- but keeping them in sync avoids the confusion if the default directory should change. |
-| OptionsInstallBld | Controls whether bld.msi will be installed. |
-| OptionsInstallCli | Controls whether cli.msi will be installed. |
-| OptionsInstallDbg | Controls whether dbg.msi will be installed. |
-| OptionsInstallIde | Controls whether ide.msi will be installed. |
-| OptionsInstallRtl | Controls whether rtl.msi will be installed. |
-| OptionsInstallSdkX86 | Controls whether the x86 SDK will be installed. |
-| OptionsInstallSdkAMD64 | Controls whether the AMD64 SDK will be installed. |
-| OptionsInstallSdkArm64 | Controls whether the Arm64 SDK will be installed. |
+| OptionsInstallCLI | Controls whether command-line tools will be installed. |
+| OptionsInstallDBG | Controls whether debugging tools will be installed. |
+| OptionsInstallIDE | Controls whether IDE integration tools will be installed. |
+| OptionsInstallUtilties | Controls whether additional utilities will be installed. |
+| OptionsInstallAndroidSDKAMD64 | Controls whether the Android AMD64 SDK will be installed. |
+| OptionsInstallAndroidSDKARM | Controls whether the Android ARM SDK will be installed. |
+| OptionsInstallAndroidSDKARM64 | Controls whether the Android ARM64 SDK will be installed. |
+| OptionsInstallAndroidSDKX86 | Controls whether the Android X86 SDK will be installed. |
+| OptionsInstallWindowsSDKX86 | Controls whether the Windows X86 SDK will be installed. |
+| OptionsInstallWindowsRedistAMD64 | Controls whether the Windows AMD64 Redistributable MSM will be installed. |
+| OptionsInstallWindowsSDKAMD64 | Controls whether the Windows AMD64 SDK will be installed. |
+| OptionsInstallWindowsRedistARM64 | Controls whether the Windows ARM64 Redistributable MSM will be installed. |
+| OptionsInstallWindowsSDKX86 | Controls whether the Windows X86 SDK will be installed. |
+| OptionsInstallWindowsRedistX86 | Controls whether the Windows X86 Redistributable MSM will be installed. |
 
 Those variables are tied to controls in the bundle theme (`installer\theme.xml`) on the Options page. For example, the install directory is an `Editbox` control that takes the `InstallRoot` name to tie itself to the `InstallRoot` variable in `installer.wxs`:
 
@@ -50,7 +56,7 @@ Those variables are tied to controls in the bundle theme (`installer\theme.xml`)
 Likewise, the feature selection controls are all checkboxes tied to the variables that control feature selection:
 
 ```xml
-<Checkbox Name="OptionsInstallIde" X="185" Y="170" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.OptionsInstallIde)</Checkbox>
+<Checkbox Name="OptionsInstallIDE" X="185" Y="170" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.OptionsInstallIDE)</Checkbox>
 ```
 
 `Checkbox` controls set variables to `1` when checked and `0` when unchecked.
@@ -60,7 +66,7 @@ The variables are used in `installer.wxs` bundle authoring to control the instal
 ```xml
 <MsiPackage
   SourceFile="!(bindpath.ide)\ide.msi"
-  InstallCondition="OptionsInstallIde = 1"
+  InstallCondition="OptionsInstallIDE = 1"
   DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
   <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
 </MsiPackage>
@@ -81,7 +87,7 @@ The same variables that drive install directory and feature selection are availa
 
 
 ```sh
-installer.exe /passive InstallRoot=X:\Swift OptionsInstallIde=0 OptionsInstallSdkX86=0 OptionsInstallSdkArm64=0
+installer.exe /passive InstallRoot=X:\Swift OptionsInstallIDE=0 OptionsInstallWindowsSDKX86=0 OptionsInstallWindowsSDKARM64=0
 ```
 
 To create a layout from a online bundle to allow for offline install:
@@ -107,7 +113,7 @@ MSBuild automatically imports Directory.Build.props files in your tree. We use D
 | BundleFlavor, IsBundleCompressed | BundleFlavor defaults to `online` to build an online bundle. Set by the invocation of MSBuild to build an online or offline bundle. Controls IsBundleCompressed. |
 | DefineConstants | Passes a subset of MSBuild properties into the WiX build as preprocessor variables. |
 | INCLUDE_SWIFT_DOCC | swift-docc is currently conditionalized out. Set it to `true` to include it. The property `SWIFT_DOCC_BUILD` defines the directory to find the artifacts. |
-| INCLUDE_X86_SDK, INCLUDE_ARM64_SDK | The x86 and Arm64 SDKs are currently conditionalized out, pending build changes. Set these to `true` to include them in the bundles. Note that bundle\theme.xml currently has commented-out checkboxes that need to be restored when the x86 and Arm64 SDKs are brought back. |
+| INCLUDE_ANDROID_ARM_SDK, INCLUDE_ANDROID_ARM64_SDK, INCLUDE_ANDROID_X86_SDK, INCLUDE_ANDROID_x86_64_SDK, INCLUDE_WINDOWS_AMD64_SDK, INCLUDE_WINDOWS_ARM64_SDK, INCLUDE_WINDOWS_X86_SDK | The included SDKs are currently conditionalized out. Set these to `true` to include them in the bundles. |
 
 
 ## SDKs

--- a/platforms/Windows/sdk/sdk.wixproj
+++ b/platforms/Windows/sdk/sdk.wixproj
@@ -1,6 +1,6 @@
 <Project Sdk="WixToolset.Sdk/4.0.5">
   <PropertyGroup>
-    <OutputName>sdk.$(ProductArchitecture)</OutputName>
+    <OutputName>sdk.windows.$(ProductArchitecture)</OutputName>
     <Platform>x86</Platform>
 
     <SwiftShimsPath>$(SDK_ROOT)\usr\lib\swift\shims</SwiftShimsPath>

--- a/platforms/Windows/sdk/sdk.wxs
+++ b/platforms/Windows/sdk/sdk.wxs
@@ -23,7 +23,7 @@
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
-    <Media Id="1" Cabinet="sdk.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+    <Media Id="1" Cabinet="sdk.windows.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
 
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(WindowsSDKUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />


### PR DESCRIPTION
Uniformly use `sdk.[os].[arch].{msi,cab}` for the name of the files and `INCLUDE_[os]_[arch]_SDK` to indicate that the SDK should be included. This makes both Windows and Android similar in their handling and naming.