### PR TITLE
WiX: make swift-inspect required for Windows

### DIFF
--- a/platforms/Windows/dbg/dbg.wixproj
+++ b/platforms/Windows/dbg/dbg.wixproj
@@ -3,8 +3,6 @@
     <DefineConstants>
       $(DefineConstants);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
-      SWIFT_INSPECT_BUILD=$(SWIFT_INSPECT_BUILD);
-      INCLUDE_SWIFT_INSPECT=$(INCLUDE_SWIFT_INSPECT);
     </DefineConstants>
   </PropertyGroup>
 </Project>

--- a/platforms/Windows/dbg/dbg.wxs
+++ b/platforms/Windows/dbg/dbg.wxs
@@ -105,14 +105,10 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_inspect" Directory="ToolsVersioned">
-      <?if $(INCLUDE_SWIFT_INSPECT) == true ?>
-        <Component Id="swift_inspect.exe">
-          <File Source="$(SWIFT_INSPECT_BUILD)\swift-inspect.exe" />
-        </Component>
-
-        <ComponentRef Id="SystemToolsEnvironmentVariables" />
-      <?endif?>
+    <ComponentGroup Id="swift_inspect">
+      <Component Directory="_usr_bin">
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-inspect.exe" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="_InternalSwiftStaticMirror" Directory="_usr_include__InternalSwiftStaticMirror">

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -107,7 +107,6 @@ MSBuild automatically imports Directory.Build.props files in your tree. We use D
 | BundleFlavor, IsBundleCompressed | BundleFlavor defaults to `online` to build an online bundle. Set by the invocation of MSBuild to build an online or offline bundle. Controls IsBundleCompressed. |
 | DefineConstants | Passes a subset of MSBuild properties into the WiX build as preprocessor variables. |
 | INCLUDE_SWIFT_DOCC | swift-docc is currently conditionalized out. Set it to `true` to include it. The property `SWIFT_DOCC_BUILD` defines the directory to find the artifacts. |
-| INCLUDE_SWIFT_INSPECT | swift-inspect is currently conditionalized out. Set it to `true` to include it. The property `SWIFT_INSPECT_BUILD` defines the directory to find the artifacts. |
 | INCLUDE_X86_SDK, INCLUDE_ARM64_SDK | The x86 and Arm64 SDKs are currently conditionalized out, pending build changes. Set these to `true` to include them in the bundles. Note that bundle\theme.xml currently has commented-out checkboxes that need to be restored when the x86 and Arm64 SDKs are brought back. |
 
 

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -59,20 +59,6 @@
     </DirectoryRef>
   </Fragment>
 
-  <Fragment>
-    <DirectoryRef Id="INSTALLROOT">
-      <Directory Name="Tools">
-        <Directory Id="ToolsVersioned" Name="$(ProductVersion)" />
-      </Directory>
-    </DirectoryRef>
-  </Fragment>
-
-  <Fragment>
-    <Component Id="SystemToolsEnvironmentVariables" Guid="5BA7803B-1EA5-45D3-8FD7-C75518C2C099" Directory="ToolsVersioned">
-      <Environment Id="Path" Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[ToolsVersioned]" />
-    </Component>
-  </Fragment>
-
   <!--
   Use RemoveFolderEx to clean up the empty subdirectories Windows Installer
   leaves when there are other directory siblings left behind, as happens when
@@ -100,11 +86,6 @@
         <RegistryValue Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersioned" Value="[ToolchainsVersioned]" />
         <util:RemoveFolderEx Property="TOOLCHAINSVERSIONED" Condition="TOOLCHAINSVERSIONED" />
       </Component>
-
-      <Component Id="VersionedDirectoryCleanupTools">
-        <RegistryValue Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolsVersioned" Value="[ToolsVersioned]" />
-        <util:RemoveFolderEx Property="TOOLSVERSIONED" Condition="TOOLSVERSIONED" />
-      </Component>
     </ComponentGroup>
 
     <Property Id="PLATFORMSVERSIONED">
@@ -121,10 +102,6 @@
 
     <Property Id="TOOLCHAINSVERSIONED">
       <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersioned" Type="directory" />
-    </Property>
-
-    <Property Id="TOOLSVERSIONED">
-      <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolsVersioned" Type="directory" />
     </Property>
   </Fragment>
 


### PR DESCRIPTION
We now can always build swift-inspect, remove the option to exclude swift-inspect. Shuffle the tool into the main toolchain installation and remove the additional support that the fragmented swift-inspect handling required.