### PR TITLE
WiX: Update the manifest to include SourceControl.dll

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -228,6 +228,9 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\PackageModelSyntax.dll" />
       </Component>
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SourceControl.dll" />
+      </Component>
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SPMBuildCore.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
`SourceControl` has been made a shared library in
swiftlang/swift-package-manager#8124.