### PR TITLE
Fix the Windows installer command line options

### DIFF
--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -56,21 +56,21 @@
             </Button>
 
             <Label X="176" Y="111" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsFeaturesLabel)</Label>
-            <Checkbox Name="OptionsInstallBld" X="176" Y="141" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Bld_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallCli" X="176" Y="159" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallDbg" X="176" Y="177" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallIde" X="176" Y="195" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallRtl" X="176" Y="213" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Rtl_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallSdkAMD64" X="176" Y="231" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallRedistAMD64" X="194" Y="249" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkAMD64">#(loc.Redist_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallSdkArm64" X="176" Y="267" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallRedistArm64" X="194" Y="285" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkArm64">#(loc.Redist_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallSdkX86" X="176" Y="303" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallRedistX86" X="194" Y="321" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSdkX86">#(loc.Redist_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSdkArm64" X="176" Y="339" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSdkAMD64" X="176" Y="357" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSdkArm" X="176" Y="375" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_arm)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSdkX86" X="176" Y="393" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallBLD" X="176" Y="141" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Bld_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallCLI" X="176" Y="159" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallDBG" X="176" Y="177" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallIDE" X="176" Y="195" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallRTL" X="176" Y="213" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Rtl_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallSDKAMD64" X="176" Y="231" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallRedistAMD64" X="194" Y="249" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSDKAMD64">#(loc.Redist_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallSDKARM64" X="176" Y="267" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallRedistARM64" X="194" Y="285" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSDKArm64">#(loc.Redist_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallSDKX86" X="176" Y="303" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Sdk_ProductName_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallRedistX86" X="194" Y="321" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallSDKX86">#(loc.Redist_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKARM4" X="176" Y="339" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKAMD64" X="176" Y="357" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKARM" X="176" Y="375" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_arm)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKX86" X="176" Y="393" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Android_Sdk_x86)</Checkbox>
 
             <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.OptionsOkButton)</Text>


### PR DESCRIPTION
Case-sensitively match the checkbox and the variable names so that the command line option like "OptionsInstallIDE=0" works.