### PR TITLE
[Android] Reference `shared.wixproj`

### DIFF
--- a/platforms/Windows/sdk/drd/sdk.wixproj
+++ b/platforms/Windows/sdk/drd/sdk.wixproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\shared\shared.wixproj" />
     <PackageReference Include="WixToolset.Heat" Version="4.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Properties defined in `shared.wixproj` are used in the Android SDK packaging project.