### PR TITLE
[6.1][package_manager] Add SourceControl dll

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -228,6 +228,9 @@
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\PackageModelSyntax.dll" />
       </Component>
       <Component>
+        <File Source="$(DEVTOOLS_ROOT)\usr\bin\SourceControl.dll" />
+      </Component>
+      <Component>
         <File Source="$(DEVTOOLS_ROOT)\usr\bin\SPMBuildCore.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
`SourceControl` has been made a shared library in
swiftlang/swift-package-manager#8124.

(cherry picked from commit 345b660f1f017ac541cfe292b51739cf0288fb58)