### PR TITLE
WiX: add `ToolchainInfo.plist` to the build tools

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -493,6 +493,12 @@
       <?endif?>
     </ComponentGroup>
 
+    <ComponentGroup Id="Configuration">
+      <Component Directory="ToolchainsVersioned">
+        <File Source="$(TOOLCHAIN_ROOT)\ToolchainInfo.plist" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="EnvironmentVariables">
       <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
         <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[_usr_bin]" />
@@ -523,6 +529,7 @@
       <ComponentGroupRef Id="ClangResources" />
       <ComponentGroupRef Id="SwiftClangResources" />
 
+      <ComponentGroupRef Id="Configuration" />
       <ComponentGroupRef Id="EnvironmentVariables" />
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>


### PR DESCRIPTION
Incorporate the `ToolchainInfo.plist` into the toolchain distribution to associate an identifier with the toolchain for ease of working with parallel installations.