### PR TITLE
WiX: remove SystemPackage from toolchain distribution

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -131,12 +131,6 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="system" Directory="_usr_bin">
-      <Component>
-        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\SystemPackage.dll" />
-      </Component>
-    </ComponentGroup>
-
     <ComponentGroup Id="CompilerPluginSupport" Directory="_usr_lib_swift_pm_ManifestAPI">
       <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" />
@@ -266,7 +260,6 @@
 
       <ComponentGroupRef Id="collections" />
       <ComponentGroupRef Id="llbuild" />
-      <ComponentGroupRef Id="system" />
       <ComponentGroupRef Id="package_manager" />
 
       <ComponentGroupRef Id="DocC" />


### PR DESCRIPTION
This library is able to be internalised into the SPM libraries that are using it. As this is a single use library, this overall helps reduce the size of the distribution and requires fewer libraries to be distributed.