### PR TITLE
Install the SourceKit plugin into Windows toolchains

### DIFF
--- a/platforms/Windows/ide/ide.wxs
+++ b/platforms/Windows/ide/ide.wxs
@@ -37,6 +37,14 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\lib\sourcekitdInProc.lib" />
       </Component>
 
+      <Component Directory="_usr_bin">
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\SwiftSourceKitPlugin.dll" />
+      </Component>
+
+      <Component Directory="_usr_bin">
+        <File Source="$(TOOLCHAIN_ROOT)\usr\lib\SwiftSourceKitClientPlugin.dll" />
+      </Component>
+
       <Component Directory="_usr_include_SourceKit">
         <File Source="$(TOOLCHAIN_ROOT)\usr\include\SourceKit\sourcekitd.h" />
       </Component>


### PR DESCRIPTION
Install the SourceKit plugin, added by https://github.com/swiftlang/sourcekit-lsp/pull/1906 into the Windows toolchains.

rdar://142909870