### PR TITLE
WiX: package up `git-clang-format`

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -31,6 +31,10 @@
       </Component>
 
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\git-clang-format" />
+      </Component>
+
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\clang-tidy.exe" />
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
This helper script enables the use of `git clang-format` for changes which is helpful for re-formatting commits, including those for the Swift toolchain.