### PR TITLE
WiX: package up SDKSettings.json in the SDKs

### DIFF
--- a/platforms/Windows/sdk/drd/sdk.wxs
+++ b/platforms/Windows/sdk/drd/sdk.wxs
@@ -1261,6 +1261,9 @@
 
     <ComponentGroup Id="Configuration">
       <Component Directory="AndroidSDK">
+        <File Source="$(SDK_ROOT)\SDKSettings.json" />
+      </Component>
+      <Component Directory="AndroidSDK">
         <File Source="$(SDK_ROOT)\SDKSettings.plist" />
       </Component>
       <Component Directory="AndroidPlatform">

--- a/platforms/Windows/sdk/win/sdk.wxs
+++ b/platforms/Windows/sdk/win/sdk.wxs
@@ -1245,6 +1245,9 @@
 
     <ComponentGroup Id="Configuration">
       <Component Directory="WindowsSDK">
+        <File Source="$(SDK_ROOT)\SDKSettings.json" />
+      </Component>
+      <Component Directory="WindowsSDK">
         <File Source="$(SDK_ROOT)\SDKSettings.plist" />
       </Component>
       <Component Directory="WindowsPlatform">


### PR DESCRIPTION
This adds a new configuration file for the SDKs to avoid a spurious warning from swift-driver.