### PR TITLE
Default InstallerPlatform to x86 if unset

### DIFF
--- a/platforms/Windows/Directory.Build.props
+++ b/platforms/Windows/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <InstallerPlatform Condition=" '$(InstallerPlatform)' == '' ">x86</InstallerPlatform>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
If unset, `InstallerPlatform` defaults to `Platform`, which may be set to an invalid value for Android. This sets `InstallerPlatform` to `x86` if it is unset from the command line, allowing for custom overrides.