### PR TITLE
WiX: add `swift-sdk` to the SPM distribution set

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -195,6 +195,9 @@
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-run.exe" />
       </Component>
       <Component>
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-sdk.exe" />
+      </Component>
+      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-test.exe" />
       </Component>
 


### PR DESCRIPTION
Package up `swift-sdk.exe` on Windows as well.