### PR TITLE
WiX: add support for toolchain variant builds

### DIFF
--- a/platforms/Windows/bld/bld.wixproj
+++ b/platforms/Windows/bld/bld.wixproj
@@ -1,10 +1,13 @@
 <Project Sdk="WixToolset.Sdk/4.0.5">
   <PropertyGroup>
+    <OutputName>bld.$(TOOLCHAIN_VARIANT)</OutputName>
+
     <DefineConstants>
       $(DefineConstants);
       TOOLCHAIN_ROOT=$(TOOLCHAIN_ROOT);
       TOOLCHAIN_ROOT_USR_LIB_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\clang;
       TOOLCHAIN_ROOT_USR_LIB_SWIFT_CLANG=$(TOOLCHAIN_ROOT)\usr\lib\swift\clang;
+      TOOLCHAIN_VARIANT=$(TOOLCHAIN_VARIANT);
       WORKAROUND_MIMALLOC_ISSUE_997=$(WORKAROUND_MIMALLOC_ISSUE_997);
     </DefineConstants>
   </PropertyGroup>

--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -14,7 +14,7 @@
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
-    <Media Id="1" Cabinet="bld.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+    <Media Id="1" Cabinet="bld.$(TOOLCHAIN_VARIANT).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
 
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(BldUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
@@ -505,7 +505,7 @@
     </ComponentGroup>
 
     <ComponentGroup Id="Configuration">
-      <Component Directory="ToolchainsVersioned">
+      <Component Directory="VersionedToolchainVariant">
         <File Source="$(TOOLCHAIN_ROOT)\ToolchainInfo.plist" />
       </Component>
     </ComponentGroup>

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -6,6 +6,8 @@
     <VCRedistDownloadUrl Condition=" '$(VCRedistDownloadUrl)' == '' AND '$(VSMajorVersion)' != '' ">https://aka.ms/vs/$(VSMajorVersion)/release/vc_redist.$(ProductArchitecture).exe</VCRedistDownloadUrl>
     <DefineConstants>
       $(DefineConstants);
+      INCLUDE_ASSERTS_TOOLCHAIN=$(INCLUDE_ASSERTS_TOOLCHAIN);
+      INCLUDE_NOASSERTS_TOOLCHAIN=$(INCLUDE_NOASSERTS_TOOLCHAIN);
       INCLUDE_ANDROID_ARM_SDK=$(INCLUDE_ANDROID_ARM_SDK);
       INCLUDE_ANDROID_ARM64_SDK=$(INCLUDE_ANDROID_ARM64_SDK);
       INCLUDE_ANDROID_X86_SDK=$(INCLUDE_ANDROID_X86_SDK);
@@ -20,8 +22,15 @@
     <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.5" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(INCLUDE_ASSERTS_TOOLCHAIN)' != '' ">
+    <ProjectReference Include="..\bld\bld.wixproj" Properties="TOOLCHAIN_VARIANT=asserts" BindName="bld.asserts" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(INCLUDE_NOASSERTS_TOOLCHAIN)' != '' ">
+    <ProjectReference Include="..\bld\bld.wixproj" Properties="TOOLCHAIN_VARIANT=noasserts" BindName="bld.noasserts" />
+  </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\bld\bld.wixproj" BindName="bld" />
     <ProjectReference Include="..\cli\cli.wixproj" BindName="cli" />
     <ProjectReference Include="..\dbg\dbg.wixproj" BindName="dbg" />
     <ProjectReference Include="..\ide\ide.wixproj" BindName="ide" />

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -77,11 +77,21 @@
         <MsiProperty Name="InstallUtilities" Value="[OptionsInstallUtilities]" />
       </MsiPackage>
 
-      <MsiPackage
-        SourceFile="!(bindpath.bld)\bld.msi"
-        DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
-        <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-      </MsiPackage>
+      <?if $(INCLUDE_ASSERTS_TOOLCHAIN) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.bld.asserts)\bld.asserts.msi"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        </MsiPackage>
+      <?endif?>
+
+      <?if $(INCLUDE_NOASSERTS_TOOLCHAIN) == true ?>
+        <MsiPackage
+          SourceFile="!(bindpath.bld.noasserts)\bld.noasserts.msi"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        </MsiPackage>
+      <?endif?>
 
       <MsiPackage
         SourceFile="!(bindpath.cli)\cli.msi"

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -112,6 +112,7 @@ MSBuild automatically imports Directory.Build.props files in your tree. We use D
 | ArePackageCabsEmbedded | Always set to false to keep the .cab files external to the .msi files. This save user disk space: Burn caches packages so it can always uninstall and repair. MSI also caches packages for uninstall. If the cab is embedded, you have two copies and MSI doesn't always use its cached copy as a source for repair. With an external .cab, MSI caches only the tiny .msi file and not the (relatively huge) .cab. |
 | BundleFlavor, IsBundleCompressed | BundleFlavor defaults to `online` to build an online bundle. Set by the invocation of MSBuild to build an online or offline bundle. Controls IsBundleCompressed. |
 | DefineConstants | Passes a subset of MSBuild properties into the WiX build as preprocessor variables. |
+| INCLUDE_ASSERTS_TOOLCHAIN,INCLUDE_NOASSERTS_TOOLCHAIN | Specifies the toolchain vaiant to include in the installer. |
 | INCLUDE_SWIFT_DOCC | swift-docc is currently conditionalized out. Set it to `true` to include it. The property `SWIFT_DOCC_BUILD` defines the directory to find the artifacts. |
 | INCLUDE_ANDROID_ARM_SDK, INCLUDE_ANDROID_ARM64_SDK, INCLUDE_ANDROID_X86_SDK, INCLUDE_ANDROID_x86_64_SDK, INCLUDE_WINDOWS_AMD64_SDK, INCLUDE_WINDOWS_ARM64_SDK, INCLUDE_WINDOWS_X86_SDK | The included SDKs are currently conditionalized out. Set these to `true` to include them in the bundles. |
 

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -38,24 +38,29 @@
   <Fragment>
     <DirectoryRef Id="INSTALLROOT">
         <Directory Name="Toolchains">
-          <Directory Id="ToolchainsVersioned" Name="$(ProductVersion)+Asserts">
-            <Directory Id="_usr" Name="usr">
-              <Directory Id="_usr_bin" Name="bin" />
-              <Directory Id="_usr_include" Name="include" />
-              <Directory Id="_usr_lib" Name="lib">
-                <Directory Id="_usr_lib_clang" Name="clang" />
-                <Directory Id="_usr_lib_swift" Name="swift">
-                  <Directory Id="_usr_lib_swift_clang" Name="clang" />
-                </Directory>
-              </Directory>
-              <Directory Id="_usr_share" Name="share">
-                <Directory Id="_usr_share_docc" Name="docc">
-                  <Directory Id="_usr_share_docc_render" Name="render" />
-                </Directory>
-              </Directory>
-            </Directory>
+          <Directory Id="VersionedToolchainVariant" Name="$(ProductVersion)+Asserts">
           </Directory>
         </Directory>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <DirectoryRef Id="VersionedToolchainVariant">
+      <Directory Id="_usr" Name="usr">
+        <Directory Id="_usr_bin" Name="bin" />
+        <Directory Id="_usr_include" Name="include" />
+        <Directory Id="_usr_lib" Name="lib">
+          <Directory Id="_usr_lib_clang" Name="clang" />
+          <Directory Id="_usr_lib_swift" Name="swift">
+            <Directory Id="_usr_lib_swift_clang" Name="clang" />
+          </Directory>
+        </Directory>
+        <Directory Id="_usr_share" Name="share">
+          <Directory Id="_usr_share_docc" Name="docc">
+            <Directory Id="_usr_share_docc_render" Name="render" />
+          </Directory>
+        </Directory>
+      </Directory>
     </DirectoryRef>
   </Fragment>
 


### PR DESCRIPTION
Add support for the toolchain variant packaging. This is intended to allow us to package a NoAsserts toolchain for distribution alongside the Asserts toolchain.