### PR TITLE
WiX: rename the product identifier

### DIFF
--- a/platforms/Windows/sdk/win/sdk.wxs
+++ b/platforms/Windows/sdk/win/sdk.wxs
@@ -18,7 +18,7 @@
   <Package
       Language="1033"
       Manufacturer="!(loc.ManufacturerName)"
-      Name="!(loc.Sdk_ProductName_$(ProductArchitecture))"
+      Name="!(loc.Windows_Sdk_ProductName_$(ProductArchitecture))"
       UpgradeCode="$(WindowsSDKUpgradeCode)"
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
@@ -614,7 +614,7 @@
     </ComponentGroup>
 
     <!-- Features -->
-    <Feature Id="SDK" AllowAbsent="no" Title="!(loc.Sdk_ProductName_$(ProductArchitecture))">
+    <Feature Id="SDK" AllowAbsent="no" Title="!(loc.Windows_Sdk_ProductName_$(ProductArchitecture))">
       <ComponentGroupRef Id="XCTest" />
       <ComponentGroupRef Id="Testing" />
       <ComponentGroupRef Id="SwiftRemoteMirror" />

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -13,12 +13,12 @@
   <String Id="Rtl_ProductName_arm64" Value="Swift Windows Runtime (ARM64)" />
   <String Id="Rtl_ProductName_amd64" Value="Swift Windows Runtime (AMD64)" />
   <String Id="Rtl_ProductName_x86" Value="Swift Windows Runtime (X86)" />
-  <String Id="Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
-  <String Id="Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
-  <String Id="Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
   <String Id="Utl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
   <String Id="Utl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
   <String Id="Utl_ProductName_x86" Value="Swift Windows Utilities (X86)" />
+  <String Id="Windows_Sdk_ProductName_arm64" Value="Swift Windows SDK (ARM64)" />
+  <String Id="Windows_Sdk_ProductName_amd64" Value="Swift Windows SDK (AMD64)" />
+  <String Id="Windows_Sdk_ProductName_x86" Value="Swift Windows SDK (X86)" />
   <String Id="Android_Sdk_arm64" Value="Swift Android SDK (ARM64)" />
   <String Id="Android_Sdk_amd64" Value="Swift Android SDK (AMD64)" />
   <String Id="Android_Sdk_arm" Value="Swift Android SDK (ARM)" />


### PR DESCRIPTION
Use the explicit platform name on the SDK identifier to match other platforms and differentiate the platforms.