### PR TITLE
WiX: correct documentation (NFC)

### DIFF
--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -113,7 +113,7 @@ MSBuild automatically imports Directory.Build.props files in your tree. We use D
 | BundleFlavor, IsBundleCompressed | BundleFlavor defaults to `online` to build an online bundle. Set by the invocation of MSBuild to build an online or offline bundle. Controls IsBundleCompressed. |
 | DefineConstants | Passes a subset of MSBuild properties into the WiX build as preprocessor variables. |
 | INCLUDE_SWIFT_DOCC | swift-docc is currently conditionalized out. Set it to `true` to include it. The property `SWIFT_DOCC_BUILD` defines the directory to find the artifacts. |
-| INCLUDE_ANDROID_ARM_SDK, INCLUDE_ANDROID_ARM64_SDK, INCLUDE_ANDROID_X86_SDK, INCLUDE_ANDROID_x86_64_SDK, INCLUDE_WINDOWS_AMD64_SDK, INCLUDE_WINDOWS_ARM64_SDK, INCLUDE_WINDOWS_X86_SDK | The included SDKs are currently conditionalized out. Set these to `true` to include them in the bundles. |
+| INCLUDE_ANDROID_ARM_SDK, INCLUDE_ANDROID_ARM64_SDK, INCLUDE_ANDROID_X86_SDK, INCLUDE_ANDROID_X86_64_SDK, INCLUDE_WINDOWS_AMD64_SDK, INCLUDE_WINDOWS_ARM64_SDK, INCLUDE_WINDOWS_X86_SDK | The included SDKs are currently conditionalized out. Set these to `true` to include them in the bundles. |
 
 
 ## SDKs


### PR DESCRIPTION
Correct the case for the parameter for WiX. The parameters are case sensitive, so it is important that we record them properly.