### PR TITLE
WiX: extract CDispatch module definition

### DIFF
--- a/platforms/Windows/sdk/CDispatch.wxi
+++ b/platforms/Windows/sdk/CDispatch.wxi
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\base.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\block.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\data.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\group.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\io.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\object.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\once.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\queue.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\source.h" />
+  </Component>
+  <Component>
+    <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\time.h" />
+  </Component>
+</Include>

--- a/platforms/Windows/sdk/drd/sdk.wxs
+++ b/platforms/Windows/sdk/drd/sdk.wxs
@@ -207,48 +207,7 @@
     </ComponentGroup>
 
     <ComponentGroup Id="libdispatch" Directory="AndroidSDK_usr_include_dispatch">
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\base.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\block.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\data.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\group.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\io.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\object.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\once.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\queue.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\source.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\time.h" />
-      </Component>
+      <?include ../CDispatch.wxi?>
       <Component Directory="AndroidSDK_usr_include_os">
         <File Source="$(SDK_ROOT)\usr\lib\swift\os\generic_base.h" />
       </Component>

--- a/platforms/Windows/sdk/win/sdk.wxs
+++ b/platforms/Windows/sdk/win/sdk.wxs
@@ -192,48 +192,7 @@
     </ComponentGroup>
 
     <ComponentGroup Id="libdispatch" Directory="WindowsSDK_usr_include_dispatch">
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\base.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\block.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\data.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\dispatch.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\group.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\introspection.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\io.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\module.modulemap" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\object.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\once.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\queue.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\semaphore.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\source.h" />
-      </Component>
-      <Component>
-        <File Source="$(SDK_ROOT)\usr\lib\swift\dispatch\time.h" />
-      </Component>
+      <?include ../CDispatch.wxi?>
       <Component Directory="WindowsSDK_usr_include_os">
         <File Source="$(SDK_ROOT)\usr\lib\swift\os\generic_base.h" />
       </Component>


### PR DESCRIPTION
The core dispatch headers are uniform across the SDKs. Ideally we would also be able to share the "os" headers, but they are installed into a separate directory and we cannot simply include them for the restructuring.