### PR TITLE
Switch to .swiftinterface files for Testing module

### DIFF
--- a/platforms/Windows/sdk/drd/sdk.wxs
+++ b/platforms/Windows/sdk/drd/sdk.wxs
@@ -60,7 +60,7 @@
           <Directory Name="Library">
             <!--
               FIXME(compnerd) this should actually be the proper version
-              of XCTest and Tesing, and needs to be reflected in the plist as well.
+              of XCTest and Testing, and needs to be reflected in the plist as well.
             -->
             <!-- XCTest -->
             <Directory Name="XCTest-development">
@@ -164,7 +164,7 @@
         <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\android\Testing.swiftmodule\$(Triple).swiftdoc" />
       </Component>
       <Component Directory="Testing.swiftmodule">
-        <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\android\Testing.swiftmodule\$(Triple).swiftmodule" />
+        <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\android\Testing.swiftmodule\$(Triple).swiftinterface" />
       </Component>
     </ComponentGroup>
 

--- a/platforms/Windows/sdk/win/sdk.wxs
+++ b/platforms/Windows/sdk/win/sdk.wxs
@@ -157,7 +157,7 @@
         <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\windows\Testing.swiftmodule\$(Triple).swiftdoc" />
       </Component>
       <Component Directory="Testing.swiftmodule">
-        <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\windows\Testing.swiftmodule\$(Triple).swiftmodule" />
+        <File Source="$(PLATFORM_ROOT)\Developer\Library\Testing-development\usr\lib\swift\windows\Testing.swiftmodule\$(Triple).swiftinterface" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
Switch from `.swiftmodule` to `.swiftinterface` files for Swift Testing (`Testing.swiftmodule`). Related to and motivated by https://github.com/swiftlang/swift-testing/pull/982.