### PR TITLE
[WiX] Remove an outdated educational note from Windows packaging.

### DIFF
--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -274,9 +274,6 @@
 
     <ComponentGroup Id="SwiftEducationalNotes" Directory="_usr_share_doc_swift_diagnostics">
       <Component>
-        <File Source="$(TOOLCHAIN_ROOT)\usr\share\doc\swift\diagnostics\complex-closure-inference.md" />
-      </Component>
-      <Component>
         <File Source="$(TOOLCHAIN_ROOT)\usr\share\doc\swift\diagnostics\dynamic-callable-requirements.md" />
       </Component>
       <Component>


### PR DESCRIPTION
I'm removing this note in https://github.com/swiftlang/swift/pull/79509/commits/f1492fe55372712bf90c4b822b2705fddcaec5d2; the restriction was lifted in SE-0362.

Starting in Swift 6.2, educational note identifiers should be stable and should not be removed in later toolchains. However, Swift 6.2 will be the first toolchain version to make that promise, so it's okay to clean up this educational note now.