### PR TITLE
WiX: package and distribute `swift-synthesize-interface`

### DIFF
--- a/platforms/Windows/dbg/dbg.wxs
+++ b/platforms/Windows/dbg/dbg.wxs
@@ -105,6 +105,12 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="SwiftSynthesizeInterface">
+      <Component Directory="_usr_bin">
+        <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-synthesize-interface.exe" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="SwiftInspect">
       <Component Directory="_usr_bin">
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-inspect.exe" />
@@ -137,6 +143,7 @@
 
       <ComponentGroupRef Id="SwiftREPL" />
       <ComponentGroupRef Id="SwiftInspect" />
+      <ComponentGroupRef Id="SwiftSynthesizeInterface" />
 
       <ComponentGroupRef Id="_InternalSwiftStaticMirror" />
 

--- a/platforms/Windows/dbg/dbg.wxs
+++ b/platforms/Windows/dbg/dbg.wxs
@@ -27,7 +27,7 @@
       </Directory>
     </DirectoryRef>
 
-    <ComponentGroup Id="lldb">
+    <ComponentGroup Id="LLDB">
       <Component Directory="_usr_bin">
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\lldb.exe" />
       </Component>
@@ -93,19 +93,19 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="lldb_server">
+    <ComponentGroup Id="LLDBServer">
       <Component Directory="_usr_bin">
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\lldb-server.exe" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_repl">
+    <ComponentGroup Id="SwiftREPL">
       <Component Directory="_usr_bin">
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\repl_swift.exe" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_inspect">
+    <ComponentGroup Id="SwiftInspect">
       <Component Directory="_usr_bin">
         <File Source="$(TOOLCHAIN_ROOT)\usr\bin\swift-inspect.exe" />
       </Component>
@@ -132,11 +132,11 @@
     </ComponentGroup>
 
     <Feature Id="DebuggingTools" AllowAbsent="no" Title="!(loc.Dbg_ProductName)">
-      <ComponentGroupRef Id="lldb" />
-      <ComponentGroupRef Id="lldb_server" />
+      <ComponentGroupRef Id="LLDB" />
+      <ComponentGroupRef Id="LLDBServer" />
 
-      <ComponentGroupRef Id="swift_repl" />
-      <ComponentGroupRef Id="swift_inspect" />
+      <ComponentGroupRef Id="SwiftREPL" />
+      <ComponentGroupRef Id="SwiftInspect" />
 
       <ComponentGroupRef Id="_InternalSwiftStaticMirror" />
 


### PR DESCRIPTION
This adds a new utility to the toolchain - `swift-synthesize-interface`.
For now, consider it a debugging utility as it is not used during the
normal compilation pipeline and thus is not a build tool. This is not
something that is normally used during CI pipelines and does not fit
into the CLI tools. As this is not currently integrated into the IDE, we
don't consider it an IDE tool either.