### PR TITLE
WiX: remove swiftinterface from distribution

### DIFF
--- a/platforms/Windows/sdk/drd/sdk.wxs
+++ b/platforms/Windows/sdk/drd/sdk.wxs
@@ -254,9 +254,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Concurrency.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Concurrency.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Concurrency.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -269,9 +271,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Differentiation.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Differentiation.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Differentiation.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -296,9 +300,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_StringProcessing.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_StringProcessing.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_StringProcessing.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -311,9 +317,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Volatile.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Volatile.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_Volatile.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -326,9 +334,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Android.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Android.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Android.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -374,9 +384,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Distributed.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -458,9 +470,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_math.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_math.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\_math.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -473,9 +487,11 @@
       <Component>
         <File Name="$(Triple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Name="$(Triple).swiftinterface" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Name="$(Triple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\Observation.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -488,9 +504,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\RegexBuilder.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\RegexBuilder.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\RegexBuilder.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -503,9 +521,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Swift.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Swift.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Swift.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -518,9 +538,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -533,9 +555,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\Synchronization.swiftmodule\$(Triple).swiftmodule" />
       </Component>

--- a/platforms/Windows/sdk/win/sdk.wxs
+++ b/platforms/Windows/sdk/win/sdk.wxs
@@ -234,9 +234,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_Concurrency.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -249,9 +251,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_Differentiation.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -276,9 +280,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\_StringProcessing.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -291,9 +297,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CRT.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -306,9 +314,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Cxx.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -321,9 +331,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\CxxStdlib.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -336,9 +348,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Distributed.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -420,9 +434,11 @@
       <Component>
         <File Name="$(Triple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\windows\Observation.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Name="$(Triple).swiftinterface" Source="$(SDK_ROOT)\usr\lib\swift\windows\Observation.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Name="$(Triple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\windows\Observation.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -435,9 +451,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\RegexBuilder.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -450,9 +468,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Swift.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -465,9 +485,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -480,9 +502,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Synchronization.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Synchronization.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Synchronization.swiftmodule\$(Triple).swiftmodule" />
       </Component>
@@ -495,9 +519,11 @@
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\$(Triple).swiftdoc" />
       </Component>
+      <!-- FIXME(swiftlang/swift#79839)
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\$(Triple).swiftinterface" />
       </Component>
+      -->
       <Component>
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\WinSDK.swiftmodule\$(Triple).swiftmodule" />
       </Component>


### PR DESCRIPTION
Remove the distribution of the resilient swift module interface due to a bug in the reserialization process.

Bug: swiftlang/swift#79839