### PR TITLE
WiX: adjust manifest for thick module for Dispatch

### DIFF
--- a/platforms/Windows/sdk/drd/sdk.wxs
+++ b/platforms/Windows/sdk/drd/sdk.wxs
@@ -226,10 +226,10 @@
         <File Source="$(SDK_ROOT)\usr\include\os\object.h" />
       </Component>
       <Component Directory="Dispatch.swiftmodule">
-        <File Name="$(Triple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\android\$(Architecture)\Dispatch.swiftdoc" />
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Dispatch.swiftmodule\$(Triple).swiftdoc" />
       </Component>
       <Component Directory="Dispatch.swiftmodule">
-        <File Name="$(Triple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\android\$(Architecture)\Dispatch.swiftmodule" />
+        <File Source="$(SDK_ROOT)\usr\lib\swift\android\Dispatch.swiftmodule\$(Triple).swiftmodule" />
       </Component>
       <Component Directory="AndroidSDK_usr_lib_swift_android_ARCH">
         <File Source="$(SDK_ROOT)\usr\lib\swift\android\libdispatch.so" />

--- a/platforms/Windows/sdk/win/sdk.wxs
+++ b/platforms/Windows/sdk/win/sdk.wxs
@@ -206,10 +206,10 @@
         <File Source="$(SDK_ROOT)\usr\include\os\object.h" />
       </Component>
       <Component Directory="Dispatch.swiftmodule">
-        <File Name="$(Triple).swiftdoc" Source="$(SDK_ROOT)\usr\lib\swift\windows\$(Architecture)\Dispatch.swiftdoc" />
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Dispatch.swiftmodule\$(Triple).swiftdoc" />
       </Component>
       <Component Directory="Dispatch.swiftmodule">
-        <File Name="$(Triple).swiftmodule" Source="$(SDK_ROOT)\usr\lib\swift\windows\$(Architecture)\Dispatch.swiftmodule" />
+        <File Source="$(SDK_ROOT)\usr\lib\swift\windows\Dispatch.swiftmodule\$(Triple).swiftmodule" />
       </Component>
       <Component Directory="WindowsSDK_usr_lib_swift_windows_ARCH">
         <File Source="$(SDK_ROOT)\usr\lib\swift\windows\dispatch.lib" />


### PR DESCRIPTION
Adjust the manifest rules to account for the fact that libdispatch now properly stages the swiftmodule in a thick module format. This avoids us having to shuffle files around when building the installer.