### PR TITLE
WiX: Add an identifier for the 6.2 branch

### DIFF
--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -51,6 +51,10 @@
     <BundleUpgradeCode>{FE697529-162A-4D62-904E-F5BC964C370F}</BundleUpgradeCode>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MajorMinorProductVersion)' == '6.2'">
+    <BundleUpgradeCode>{E41E5E4A-6DA1-435A-A1DC-7CB3E14664F4}</BundleUpgradeCode>
+  </PropertyGroup>
+
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);


### PR DESCRIPTION
  - **Explanation**:
    The 6.2 release requires an identifier to buid.
  - **Scope**:
    Adding an identifier for the 6.2 build.
  - **Issues**:
    - N/A
  - **Original PRs**:
    #408 
  - **Risk**:
    Very low. 
  - **Testing**:
    The release 6.2 branch should build properly.
  - **Reviewers**:
    @compnerd 
