### PR TITLE
WiX: remove workaround for mimalloc

### DIFF
--- a/platforms/Windows/bld/bld.wixproj
+++ b/platforms/Windows/bld/bld.wixproj
@@ -4,7 +4,6 @@
       $(DefineConstants);
       _USR_LIB_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\clang;
       _USR_LIB_SWIFT_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang;
-      WORKAROUND_MIMALLOC_ISSUE_997=$(WORKAROUND_MIMALLOC_ISSUE_997);
     </DefineConstants>
   </PropertyGroup>
 

--- a/platforms/Windows/bld/bld.wxs
+++ b/platforms/Windows/bld/bld.wxs
@@ -535,15 +535,6 @@
           <File Source="$(ToolchainRoot)\usr\bin\mimalloc-redirect-arm64.dll" />
         <?endif?>
       </Component>
-      <?if $(WORKAROUND_MIMALLOC_ISSUE_997) = True?>
-        <Component>
-          <?if $(ProductArchitecture) = "amd64" ?>
-            <File Source="$(ToolchainRoot)\usr\bin\mimalloc-redirect-arm64.dll" />
-          <?elseif $(ProductArchitecture) = "arm64" ?>
-            <File Source="$(ToolchainRoot)\usr\bin\mimalloc-redirect.dll" />
-          <?endif?>
-        </Component>
-      <?endif?>
     </ComponentGroup>
 
     <ComponentGroup Id="Configuration">


### PR DESCRIPTION
Remove the extra library packaging which was a workaround for mimalloc adding a reference to foreign architecture modules.