### PR TITLE
Installer: Fix typoes

### DIFF
--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -108,7 +108,7 @@
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
       </MsiPackage>
 
-      <?if $(IncludeAndroid) == true?>
+      <?if $(IncludeAndroid) == True?>
         <MsiPackage
           SourceFile="!(bindpath.platform.android)\android.msi"
           InstallCondition="OptionsInstallAndroidPlatform = 1"
@@ -122,7 +122,7 @@
         </MsiPackage>
       <?endif?>
 
-      <?if $(IncludeWindows) == true?>
+      <?if $(IncludeWindows) == True?>
         <MsiPackage
           SourceFile="!(bindpath.platform.windows)\windows.msi"
           InstallCondition="OptionsInstallWindowsPlatform = 1"

--- a/platforms/Windows/platforms/android/android.wxs
+++ b/platforms/Windows/platforms/android/android.wxs
@@ -2241,7 +2241,7 @@
 
     <?if $(IncludeX64) = True?>
       <Feature Id="amd64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_amd64)">
-        <Level Condition="InstallX64SDK = 0" Value="0" />
+        <Level Condition="InstallAMD64SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="XCTest.x64" />
         <ComponentGroupRef Id="Testing.x64" />


### PR DESCRIPTION
`True` is the proper boolean value for the msbuild preprocessor. `InstallAMD64SDK` is the proper name for the Android x64 SDK condition.