### PR TITLE
WiX: package the experimental runtime builds

### DIFF
--- a/platforms/Windows/bld/asserts/bld.asserts.wixproj
+++ b/platforms/Windows/bld/asserts/bld.asserts.wixproj
@@ -4,6 +4,7 @@
       $(DefineConstants);
       _USR_LIB_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\clang;
       _USR_LIB_SWIFT_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang;
+      _USR_LIB_SWIFT_STATIC_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift_static\clang;
     </DefineConstants>
     <OutputName>bld.asserts</OutputName>
   </PropertyGroup>
@@ -28,6 +29,18 @@
       <ComponentGroupName>SwiftClangResources_asserts</ComponentGroupName>
       <DirectoryRefId>_usr_lib_swift_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_SWIFT_CLANG</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- FIXME(#81557) this needs to be properly staged once the sanitizers are included -->
+    <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang">
+      <ComponentGroupName>SwiftStaticClangResources_asserts</ComponentGroupName>
+      <DirectoryRefId>_usr_lib_swift_static_clang</DirectoryRefId>
+      <PreprocessorVariable>var._USR_LIB_SWIFT_STATIC_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>
       <SuppressRootDirectory>true</SuppressRootDirectory>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -573,6 +573,7 @@
 
       <ComponentGroupRef Id="ClangResources_asserts" />
       <ComponentGroupRef Id="SwiftClangResources_asserts" />
+      <ComponentGroupRef Id="SwiftStaticClangResources_asserts" />
 
       <ComponentGroupRef Id="Configuration" />
       <ComponentGroupRef Id="EnvironmentVariables" />

--- a/platforms/Windows/platforms/CDispatch.wxi
+++ b/platforms/Windows/platforms/CDispatch.wxi
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\base.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\block.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\data.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\dispatch.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\group.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\introspection.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\io.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\module.modulemap" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\object.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\once.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\queue.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\semaphore.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\source.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\dispatch\time.h" />
   </Component>
 </Include>

--- a/platforms/Windows/platforms/_FoundationCShims.wxi
+++ b/platforms/Windows/platforms/_FoundationCShims.wxi
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\bplist_shims.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\CFUniCharBitmapData.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\CFUniCharBitmapData.inc.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\filemanager_shims.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\io_shims.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\module.modulemap" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\platform_shims.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\string_shims.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\uuid.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\_CShimsMacros.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\_CShimsTargetConditionals.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\_CStdlib.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_FoundationCShims\_FoundationCShims.h" />
   </Component>
 </Include>

--- a/platforms/Windows/platforms/_FoundationUnicode.wxi
+++ b/platforms/Windows/platforms/_FoundationUnicode.wxi
@@ -1,618 +1,618 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\alphaindex.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\appendable.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\basictz.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\brkiter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\bytestream.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\bytestrie.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\bytestriebuilder.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\calendar.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\caniter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\casemap.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\char16ptr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\chariter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\choicfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\coleitr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\coll.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\compactdecimalformat.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\curramt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\currpinf.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\currunit.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\datefmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dbbi.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dcfmtsym.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\decimfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\displayoptions.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\docmain.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dtfmtsym.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dtintrv.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dtitvfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dtitvinf.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dtptngen.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\dtrule.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\edits.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\enumset.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\errorcode.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\fieldpos.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\filteredbrk.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\fmtable.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\format.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\formattedvalue.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\formattednumber.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\fpositer.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\gender.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\gregocal.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\icudataver.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\icuplug.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\idna.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\listformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\localebuilder.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\localematcher.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\localpointer.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\locdspnm.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\locid.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\measfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\measunit.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\measure.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messagepattern.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\module.modulemap" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\msgfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\normalizer2.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\normlzr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\nounit.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\numberformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\numberrangeformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\numfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\numsys.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\parseerr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\parsepos.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\platform.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\plurfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\plurrule.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ptypes.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\putil.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\rbbi.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\rbnf.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\rbtz.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\regex.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\region.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\reldatefmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\rep.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\resbund.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\schriter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\scientificnumberformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\search.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\selfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\simpleformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\simplenumberformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\simpletz.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\smpdtfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\sortkey.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\std_string.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\strenum.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\stringoptions.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\stringpiece.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\stringtriebuilder.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\stsearch.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\symtable.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tblcoll.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\timezone.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tmunit.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tmutamt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tmutfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\translit.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tzfmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tznames.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tzrule.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\tztrans.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ualoc.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uameasureformat.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uameasureunit.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uatimeunitformat.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ubidi.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ubiditransform.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ubrk.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucal.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucasemap.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucat.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uchar.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucharstrie.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucharstriebuilder.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uchriter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uclean.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucnv.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucnvsel.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucnv_cb.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucnv_err.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucol.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucoleitr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uconfig.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucpmap.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucptrie.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucsdet.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ucurr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udat.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udata.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udateintervalformat.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udatintv.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udatpg.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udisplaycontext.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\udisplayoptions.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uenum.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ufieldpositer.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uformattable.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uformattedvalue.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uformattednumber.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ugender.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uidna.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uiter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uldnames.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ulistformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uloc.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ulocale.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ulocbuilder.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ulocdata.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\umachine.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\umisc.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\umsg.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\umutablecptrie.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unifilt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unifunct.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unimatch.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unirepl.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uniset.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unistr.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unorm.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unorm2.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unum.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unumberformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unumberoptions.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unumberrangeformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\unumsys.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uobject.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uplrule.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\upluralrules.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\urbtok.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uregex.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uregion.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ureldatefmt.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\urename.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\urep.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ures.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uscript.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\usearch.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uset.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\usetiter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ushape.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\usimplenumberformatter.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uspoof.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\usprep.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ustdio.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ustream.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ustring.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\ustringtrie.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utext.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utf.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utf16.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utf32.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utf8.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utf_old.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utmscale.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utrace.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utrans.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\utypes.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uvernum.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\uversion.h" />
   </Component>
-  <Component>
+  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\vtzone.h" />
   </Component>
 </Include>

--- a/platforms/Windows/platforms/android/android.wxs
+++ b/platforms/Windows/platforms/android/android.wxs
@@ -539,7 +539,9 @@
 
     <!-- _FoundationUnicode -->
     <ComponentGroup Id="_FoundationUnicode" Directory="AndroidSDK_usr_include__foundation_unicode">
+      <?define Disk = 1?>
       <?include ../_FoundationUnicode.wxi?>
+      <?undef Disk?>
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
@@ -573,7 +575,9 @@
 
     <!-- _FoundationCShims -->
     <ComponentGroup Id="_FoundationCShims" Directory="AndroidSDK_usr_include__FoundationCShims">
+      <?define Disk = 1?>
       <?include ../_FoundationCShims.wxi?>
+      <?undef Disk?>
     </ComponentGroup>
 
     <!-- _Builtin_float -->

--- a/platforms/Windows/platforms/windows/windows.wixproj
+++ b/platforms/Windows/platforms/windows/windows.wixproj
@@ -39,4 +39,15 @@
       <SuppressRootDirectory>true</SuppressRootDirectory>
     </HarvestDirectory>
   </ItemGroup>
+
+  <ItemGroup>
+    <HarvestDirectory Include="$(SwiftShimsPath)">
+      <ComponentGroupName>ExperimentalSwiftShims</ComponentGroupName>
+      <DirectoryRefId>WindowsExperimentalSDK_usr_lib_swift_shims</DirectoryRefId>
+      <PreprocessorVariable>var.SwiftShimsPath</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
 </Project>

--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -11,15 +11,21 @@
     <?define PlatformRoot = "$(ImageRoot)\Platforms\Windows.platform"?>
     <?define SDKRoot = "$(PlatformRoot)\Developer\SDKs\Windows.sdk"?>
 
+    <?define ExperimentalSDKRoot = "$(PlatformRoot)\Developer\SDKs\WindowsExperimental.sdk"?>
+
     <Media Id="1" Cabinet="windows.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+    <Media Id="5" Cabinet="windows.experimental.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?if $(IncludeARM64) = True?>
       <Media Id="2" Cabinet="sdk.windows.arm64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="6" Cabinet="sdk.windows.experimental.arm64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
     <?if $(IncludeX64) = True?>
       <Media Id="3" Cabinet="sdk.windows.x64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="7" Cabinet="sdk.windows.experimental.x64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
     <?if $(IncludeX86) = True?>
       <Media Id="4" Cabinet="sdk.windows.x86.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="8" Cabinet="sdk.windows.experimental.x86.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
 
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(WindowsPlatformUpgradeCode)" />
@@ -163,6 +169,66 @@
                   </Directory>
                 </Directory>
                 <Directory Id="WindowsSDK_usr_share" Name="share" />
+              </Directory>
+            </Directory>
+
+            <!-- WindowsExperimental.sdk -->
+            <Directory Id="WindowsExperimentalSDK" Name="WindowsExperimental.sdk">
+              <Directory Name="usr">
+                <Directory Name="include">
+                  <Directory Id="WindowsExperimentalSDK_usr_include_Block" Name="Block" />
+                  <Directory Id="WindowsExperimentalSDK_usr_include_dispatch" Name="dispatch" />
+                  <Directory Id="WindowsExperimentalSDK_usr_include_os" Name="os" />
+                  <Directory Id="WindowsExperimentalSDK_usr_include__foundation_unicode" Name="_foundation_unicode" />
+                  <Directory Id="WindowsExperimentalSDK_usr_include__FoundationCShims" Name="_Foundation_CShims" />
+                </Directory>
+                <Directory Name="lib">
+                  <Directory Name="swift">
+                    <Directory Id="WindowsExperimentalSDK_usr_lib_swift_shims" Name="shims" />
+                    <Directory Name="windows">
+                      <?if $(IncludeARM64) = True?>
+                        <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows_arm64" Name="aarch64" DiskId="6" />
+                      <?endif?>
+                      <?if $(IncludeX64) = True?>
+                        <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows_x64" Name="x86_64" DiskId="7" />
+                      <?endif?>
+                      <?if $(IncludeX86) = True?>
+                        <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows_x86" Name="i686" DiskId="8" />
+                      <?endif?>
+                    </Directory>
+                  </Directory>
+                  <Directory Name="swift_static">
+                    <Directory Name="windows">
+                      <Directory Id="lib_Builtin_float.swiftmodule" Name="Builtin_float.swiftmodule" />
+                      <Directory Id="lib_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule" />
+                      <Directory Id="lib_FoundationCollections.swiftmodule" Name="_FoundationCollections.swiftmodule" />
+                      <Directory Id="lib_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule" />
+                      <Directory Id="lib_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule" />
+                      <Directory Id="libCRT.swiftmodule" Name="CRT.swiftmodule" />
+                      <Directory Id="libDispatch.swiftmodule" Name="Dispatch.swiftmodule" />
+                      <Directory Id="libFoundation.swiftmodule" Name="Foundation.swiftmodule" />
+                      <Directory Id="libFoundationEssentials.swiftmodule" Name="FoundationEssentials.swiftmodule" />
+                      <Directory Id="libFoundationInternationalization.swiftmodule" Name="FoundationInternationalization.swiftmodule" />
+                      <Directory Id="libFoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
+                      <Directory Id="libFoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="libRegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
+                      <Directory Id="libSwift.swiftmodule" Name="Swift.swiftmodule" />
+                      <Directory Id="libSwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
+                      <Directory Id="libSynchronization.swiftmodule" Name="Synchronization.swiftmodule" />
+                      <Directory Id="libWinSDK.swiftmodule" Name="WinSDK.swiftmodule" />
+                      <?if $(IncludeARM64) = True?>
+                        <Directory Id="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64" Name="aarch64" DiskId="6" />
+                      <?endif?>
+                      <?if $(IncludeX64) = True?>
+                        <Directory Id="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64" Name="x86_64" DiskId="7" />
+                      <?endif?>
+                      <?if $(IncludeX86) = True?>
+                        <Directory Id="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86" Name="i686" DiskId="8" />
+                      <?endif?>
+                    </Directory>
+                  </Directory>
+                </Directory>
+                <Directory Id="WindowsExperimentalSDK_usr_share" Name="share" />
               </Directory>
             </Directory>
           </Directory>
@@ -393,9 +459,38 @@
       </ComponentGroup>
     <?endif?>
 
+    <ComponentGroup Id="libBlocksRuntime" Directory="WindowsExperimentalSDK_usr_include_Block">
+      <Component DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\include\Block\Block.h" />
+      </Component>
+    </ComponentGroup>
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libBlocksRuntime.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\BlocksRuntime.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libBlocksRuntime.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\BlocksRuntime.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libBlocksRuntime.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\BlocksRuntime.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- libdispatch -->
-    <ComponentGroup Id="libdispatch" Directory="WindowsSDK_usr_include_dispatch">
+    <ComponentGroup Id="dispatch" Directory="WindowsSDK_usr_include_dispatch">
+      <?define Disk = 1?>
       <?include ../CDispatch.wxi?>
+      <?undef Disk?>
 
       <Component Directory="WindowsSDK_usr_include_os">
         <File Source="$(SDKRoot)\usr\include\os\generic_base.h" />
@@ -412,7 +507,7 @@
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
-      <ComponentGroup Id="libdispatch.arm64">
+      <ComponentGroup Id="dispatch.arm64">
         <Component Directory="Dispatch.swiftmodule" DiskId="2">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
         </Component>
@@ -429,7 +524,7 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
-      <ComponentGroup Id="libdispatch.x64">
+      <ComponentGroup Id="dispatch.x64">
         <Component Directory="Dispatch.swiftmodule" DiskId="3">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
         </Component>
@@ -446,7 +541,7 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
-      <ComponentGroup Id="libdispatch.x86">
+      <ComponentGroup Id="dispatch.x86">
         <Component Directory="Dispatch.swiftmodule" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
         </Component>
@@ -463,9 +558,95 @@
       </ComponentGroup>
     <?endif?>
 
+    <ComponentGroup Id="libdispatch" Directory="WindowsExperimentalSDK_usr_include_dispatch">
+      <?define Disk = 5?>
+      <?include ../CDispatch.wxi?>
+      <?undef Disk?>
+
+      <Component Directory="WindowsExperimentalSDK_usr_include_os" DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\include\os\generic_base.h" />
+      </Component>
+      <Component Directory="WindowsExperimentalSDK_usr_include_os" DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\include\os\generic_unix_base.h" />
+      </Component>
+      <Component Directory="WindowsExperimentalSDK_usr_include_os" DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\include\os\generic_win_base.h" />
+      </Component>
+      <Component Directory="WindowsExperimentalSDK_usr_include_os" DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\include\os\object.h" />
+      </Component>
+    </ComponentGroup>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libdispatch.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\dispatch.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libdispatch.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\dispatch.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libdispatch.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\dispatch.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libswiftDispatch.arm64" Directory="libDispatch.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64" DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftDispatch.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libswiftDispatch.x64" Directory="libDispatch.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64" DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftDispatch.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libswiftDispatch.x86" Directory="libDispatch.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86" DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftDispatch.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- _FoundationUnicode -->
     <ComponentGroup Id="_FoundationUnicode" Directory="WindowsSDK_usr_include__foundation_unicode">
+      <?define Disk = 1?>
       <?include ../_FoundationUnicode.wxi?>
+      <?undef Disk?>
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
@@ -490,10 +671,68 @@
       </ComponentGroup>
     <?endif?>
 
+    <ComponentGroup Id="lib_FoundationUnicode" Directory="WindowsExperimentalSDK_usr_include__foundation_unicode">
+      <?define Disk = 5?>
+      <?include ../_FoundationUnicode.wxi?>
+      <?undef Disk?>
+    </ComponentGroup>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_FoundationUnicode.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\_FoundationICU.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_FoundationUnicode.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\_FoundationICU.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_FoundationUnicode.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\_FoundationICU.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- _FoundationCShims -->
     <ComponentGroup Id="_FoundationCShims" Directory="WindowsSDK_usr_include__FoundationCShims">
+      <?define Disk = 1?>
       <?include ../_FoundationCShims.wxi?>
+      <?undef Disk?>
     </ComponentGroup>
+
+    <ComponentGroup Id="lib_FoundationCShims" Directory="WindowsExperimentalSDK_usr_include__FoundationCShims">
+      <?define Disk = 5?>
+      <?include ../_FoundationCShims.wxi?>
+      <?undef Disk?>
+    </ComponentGroup>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\_FoundationCShims.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\_FoundationCShims.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\_FoundationCShims.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
 
     <!-- _Builtin_float -->
     <?if $(IncludeARM64) = True?>
@@ -548,6 +787,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_Builtin_float.arm64" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswift_Builtin_float.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_Builtin_float.x64" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswift_Builtin_float.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_Builtin_float.x86" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86" DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswift_Builtin_float.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- _Concurrency -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_Concurrency.arm64" Directory="_Concurrency.swiftmodule">
@@ -597,6 +879,49 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\swift_Concurrency.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_Concurrency.arm64" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswift_Concurrency.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_Concurrency.x64" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswift_Concurrency.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_Concurrency.x86" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswift_Concurrency.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -698,6 +1023,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_RegexParser.arm64" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswift_RegexParser.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_RegexParser.x64" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswift_RegexParser.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_RegexParser.x86" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswift_RegexParser.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- _StringProcessing -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_StringProcessing.arm64" Directory="_StringProcessing.swiftmodule">
@@ -747,6 +1115,49 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\swift_StringProcessing.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_StringProcessing.arm64" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswift_StringProcessing.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_StringProcessing.x64" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswift_StringProcessing.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_StringProcessing.x86" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswift_StringProcessing.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -853,6 +1264,49 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\swiftCRT.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libCRT.arm64" Directory="libCRT.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftCRT.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libCRT.x64" Directory="libCRT.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftCRT.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libCRT.x86" Directory="libCRT.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftCRT.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1066,6 +1520,67 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_FoundationCollections.arm64" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="6">
+          <!-- FIXME(swiftlang/swift-foundation#1230)
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+          -->
+          <File Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <!-- FIXME(swiftlang/swift-foundation#1230)
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+          -->
+          <File Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\lib_FoundationCollections.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_FoundationCollections.x64" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="7">
+          <!-- FIXME(swiftlang/swift-foundation#1230)
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+          -->
+          <File Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <!-- FIXME(swiftlang/swift-foundation#1230)
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+          -->
+          <File Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\lib_FoundationCollections.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_FoundationCollections.x86" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="8">
+          <!-- FIXME(swiftlang/swift-foundation#1230)
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+          -->
+          <File Name="i686-unknown-windows-msvc.swiftdoc" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <!-- FIXME(swiftlang/swift-foundation#1230)
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+          -->
+          <File Name="i686-unknown-windows-msvc.swiftmodule" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\lib_FoundationCollections.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- FoundationEssentials -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="FoundationEssentials.arm64" Directory="FoundationEssentials.swiftmodule">
@@ -1106,6 +1621,49 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\FoundationEssentials.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libFoundationEssentials.arm64" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libFoundationEssentials.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libFoundationEssentials.x64" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libFoundationEssentials.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libFoundationEssentials.x86" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libFoundationEssentials.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1154,6 +1712,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libFoundationInternationalization.arm64" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libFoundationInternationalization.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libFoundationInternationalization.x64" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libFoundationInternationalization.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libFoundationInternationalization.x86" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libFoundationInternationalization.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- Foundation -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Foundation.arm64" Directory="Foundation.swiftmodule">
@@ -1193,6 +1794,48 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\Foundation.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libFoundation.arm64" Directory="libFoundation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libFoundation.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libFoundation.x64" Directory="libFoundation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libFoundation.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libFoundation.x86" Directory="libFoundation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libFoundation.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1241,6 +1884,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libFoundationNetworking.arm64" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libFoundationNetworking.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libFoundationNetworking.x64" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libFoundationNetworking.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libFoundationNetworking.x86" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libFoundationNetworking.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- FoundationXML -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="FoundationXML.arm64" Directory="FoundationXML.swiftmodule">
@@ -1281,6 +1967,49 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\FoundationXML.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libFoundationXML.arm64" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libFoundationXML.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libFoundationXML.x64" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libFoundationXML.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libFoundationXML.x86" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libFoundationXML.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1391,6 +2120,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libRegexBuilder.arm64" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftRegexBuilder.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libRegexBuilder.x64" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftRegexBuilder.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libRegexBuilder.x86" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftRegexBuilder.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- Swift -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Swift.arm64" Directory="Swift.swiftmodule">
@@ -1437,6 +2209,49 @@
         </Component>
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\swiftCore.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libSwift.arm64" Directory="libSwift.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftCore.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libSwift.x64" Directory="libSwift.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftCore.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libSwift.x86" Directory="libSwift.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftCore.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1494,6 +2309,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libSwiftOnoneSupport.arm64" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftSwiftOnoneSupport.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libSwiftOnoneSupport.x64" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftSwiftOnoneSupport.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libSwiftOnoneSupport.x86" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftSwiftOnoneSupport.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- Synchronization -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Synchronization.arm64" Directory="Synchronization.swiftmodule">
@@ -1547,6 +2405,49 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libSynchronization.arm64" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64" DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftSynchronization.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libSynchronization.x64" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64" DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftSynchronization.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libSynchronization.x86" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86" DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftSynchronization.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- WinSDK -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="WinSDK.arm64" Directory="WinSDK.swiftmodule">
@@ -1596,6 +2497,49 @@
 
         <Component Directory="WindowsSDK_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(SDKRoot)\usr\lib\swift\windows\i686\swiftWinSDK.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libWinSDK.arm64" Directory="libWinSDK.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\libswiftWinSDK.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libWinSDK.x64" Directory="libWinSDK.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\libswiftWinSDK.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libWinSDK.x86" Directory="libWinSDK.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\libswiftWinSDK.lib" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1658,6 +2602,40 @@
       </ComponentGroup>
     <?endif?>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="ExperimentalRegistrar.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftrt.obj" />
+        </Component>
+        <!-- FIXME(swiftlang/swift-driver#1902) - this should be in the static resource directory -->
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftrtT.obj" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="ExperimentalRegistrar.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftrt.obj" />
+        </Component>
+        <!-- FIXME(swiftlang/swift-driver#1902) - this should be in the static resource directory -->
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftrtT.obj" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="ExperimentalRegistrar.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftrt.obj" />
+        </Component>
+        <!-- FIXME(swiftlang/swift-driver#1902) - this should be in the static resource directory -->
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftrtT.obj" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- clang modules -->
     <ComponentGroup Id="AuxiliaryFiles" Directory="WindowsSDK_usr_share">
       <Component DiskId="1">
@@ -1674,7 +2652,23 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="ExperimentalAuxiliaryFiles" Directory="WindowsExperimentalSDK_usr_share">
+      <Component DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\share\ucrt.modulemap" />
+      </Component>
+      <Component DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\share\winsdk.modulemap" />
+      </Component>
+      <Component DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\share\vcruntime.apinotes" />
+      </Component>
+      <Component DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\usr\share\vcruntime.modulemap" />
+      </Component>
+    </ComponentGroup>
+
     <!-- Configuration -->
+    <!-- NOTE(compnerd): do not remove this without preserving the Platform Info.plist -->
     <ComponentGroup Id="Configuration">
       <Component Directory="WindowsSDK" DiskId="1">
         <File Source="$(SDKRoot)\SDKSettings.json" />
@@ -1685,6 +2679,20 @@
       <Component Directory="WindowsPlatform" DiskId="1">
         <File Source="$(PlatformRoot)\Info.plist" />
       </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="ExperimentalConfiguration">
+      <Component Directory="WindowsExperimentalSDK" DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\SDKSettings.json" />
+      </Component>
+      <Component Directory="WindowsExperimentalSDK" DiskId="5">
+        <File Source="$(ExperimentalSDKRoot)\SDKSettings.plist" />
+      </Component>
+      <!--
+      <Component Directory="WindowsPlatform" DiskId="5">
+        <File Source="$(PlatformRoot)\Info.plist" />
+      </Component>
+      -->
     </ComponentGroup>
 
     <!-- Redistributables -->
@@ -1710,11 +2718,52 @@
       </Component>
     </ComponentGroup>
 
+    <!-- CoreFoundation -->
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="CoreFoundation.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\CoreFoundation.lib" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\_CFURLSessionInterface.lib" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\_CFXMLInterface.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="CoreFoundation.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\CoreFoundation.lib" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\_CFURLSessionInterface.lib" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\_CFXMLInterface.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="CoreFoundation.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\CoreFoundation.lib" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\_CFURLSessionInterface.lib" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\_CFXMLInterface.lib" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- Features -->
     <Feature Id="SDK" AllowAbsent="no" Title="!(loc.Plt_ProductName_Windows)">
       <ComponentGroupRef Id="SwiftRemoteMirror" />
       <ComponentGroupRef Id="BlocksRuntime" />
-      <ComponentGroupRef Id="libdispatch" />
+      <ComponentGroupRef Id="dispatch" />
       <ComponentGroupRef Id="_FoundationUnicode" />
       <ComponentGroupRef Id="_FoundationCShims" />
 
@@ -1741,7 +2790,7 @@
         <ComponentGroupRef Id="SwiftRemoteMirror.arm64" />
 
         <ComponentGroupRef Id="BlocksRuntime.arm64" />
-        <ComponentGroupRef Id="libdispatch.arm64" />
+        <ComponentGroupRef Id="dispatch.arm64" />
 
         <ComponentGroupRef Id="CRT.arm64" />
         <ComponentGroupRef Id="WinSDK.arm64" />
@@ -1785,7 +2834,7 @@
         <ComponentGroupRef Id="SwiftRemoteMirror.x64" />
 
         <ComponentGroupRef Id="BlocksRuntime.x64" />
-        <ComponentGroupRef Id="libdispatch.x64" />
+        <ComponentGroupRef Id="dispatch.x64" />
 
         <ComponentGroupRef Id="CRT.x64" />
         <ComponentGroupRef Id="WinSDK.x64" />
@@ -1829,7 +2878,7 @@
         <ComponentGroupRef Id="SwiftRemoteMirror.x86" />
 
         <ComponentGroupRef Id="BlocksRuntime.x86" />
-        <ComponentGroupRef Id="libdispatch.x86" />
+        <ComponentGroupRef Id="dispatch.x86" />
 
         <ComponentGroupRef Id="CRT.x86" />
         <ComponentGroupRef Id="WinSDK.x86" />
@@ -1860,6 +2909,111 @@
 
         <!-- Redistributable -->
         <ComponentRef Id="rtl.x86.msm" />
+      </Feature>
+    <?endif?>
+
+    <Feature Id="ExperimentalSDK" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental)">
+      <ComponentGroupRef Id="lib_FoundationUnicode" />
+      <ComponentGroupRef Id="lib_FoundationCShims" />
+      <ComponentGroupRef Id="libBlocksRuntime" />
+      <ComponentGroupRef Id="libdispatch" />
+
+      <ComponentGroupRef Id="ExperimentalAuxiliaryFiles" />
+      <ComponentGroupRef Id="ExperimentalConfiguration" />
+      <ComponentGroupRef Id="ExperimentalSwiftShims" />
+
+      <!-- MSI management Components -->
+      <ComponentGroupRef Id="VersionedDirectoryCleanup" />
+    </Feature>
+
+    <?if $(IncludeARM64) = True?>
+      <Feature Id="ExperimentalARM64" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_arm64)">
+        <ComponentGroupRef Id="CoreFoundation.arm64" />
+        <ComponentGroupRef Id="lib_Builtin_float.arm64" />
+        <ComponentGroupRef Id="lib_Concurrency.arm64" />
+        <ComponentGroupRef Id="lib_FoundationCollections.arm64" />
+        <ComponentGroupRef Id="lib_FoundationCShims.arm64" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.arm64" />
+        <ComponentGroupRef Id="lib_RegexParser.arm64" />
+        <ComponentGroupRef Id="lib_StringProcessing.arm64" />
+        <ComponentGroupRef Id="libBlocksRuntime.arm64" />
+        <ComponentGroupRef Id="libCRT.arm64" />
+        <ComponentGroupRef Id="libdispatch.arm64" />
+        <ComponentGroupRef Id="libFoundation.arm64" />
+        <ComponentGroupRef Id="libFoundationEssentials.arm64" />
+        <ComponentGroupRef Id="libFoundationInternationalization.arm64" />
+        <ComponentGroupRef Id="libFoundationNetworking.arm64" />
+        <ComponentGroupRef Id="libFoundationXML.arm64" />
+        <ComponentGroupRef Id="libRegexBuilder.arm64" />
+        <ComponentGroupRef Id="libSwift.arm64" />
+        <ComponentGroupRef Id="libswiftDispatch.arm64" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.arm64" />
+        <ComponentGroupRef Id="libSynchronization.arm64" />
+        <ComponentGroupRef Id="libWinSDK.arm64" />
+
+        <ComponentGroupRef Id="ExperimentalRegistrar.arm64" />
+      </Feature>
+    <?endif?>
+
+    <?if $(IncludeX64) = True?>
+      <Feature Id="ExperimentalX64" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_amd64)">
+        <Level Condition="InstallX64ExperimentalSDK = 1" Value="1" />
+
+        <ComponentGroupRef Id="CoreFoundation.x64" />
+        <ComponentGroupRef Id="lib_Builtin_float.x64" />
+        <ComponentGroupRef Id="lib_Concurrency.x64" />
+        <ComponentGroupRef Id="lib_FoundationCollections.x64" />
+        <ComponentGroupRef Id="lib_FoundationCShims.x64" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.x64" />
+        <ComponentGroupRef Id="lib_RegexParser.x64" />
+        <ComponentGroupRef Id="lib_StringProcessing.x64" />
+        <ComponentGroupRef Id="libBlocksRuntime.x64" />
+        <ComponentGroupRef Id="libCRT.x64" />
+        <ComponentGroupRef Id="libdispatch.x64" />
+        <ComponentGroupRef Id="libFoundation.x64" />
+        <ComponentGroupRef Id="libFoundationEssentials.x64" />
+        <ComponentGroupRef Id="libFoundationInternationalization.x64" />
+        <ComponentGroupRef Id="libFoundationNetworking.x64" />
+        <ComponentGroupRef Id="libFoundationXML.x64" />
+        <ComponentGroupRef Id="libRegexBuilder.x64" />
+        <ComponentGroupRef Id="libSwift.x64" />
+        <ComponentGroupRef Id="libswiftDispatch.x64" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.x64" />
+        <ComponentGroupRef Id="libSynchronization.x64" />
+        <ComponentGroupRef Id="libWinSDK.x64" />
+
+        <ComponentGroupRef Id="ExperimentalRegistrar.x64" />
+      </Feature>
+    <?endif?>
+
+    <?if $(IncludeX86) = True?>
+      <Feature Id="ExperimentalX86" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_x86)">
+        <Level Condition="InstallX86ExperimentalSDK = 1" Value="1" />
+
+        <ComponentGroupRef Id="CoreFoundation.x86" />
+        <ComponentGroupRef Id="lib_Builtin_float.x86" />
+        <ComponentGroupRef Id="lib_Concurrency.x86" />
+        <ComponentGroupRef Id="lib_FoundationCollections.x86" />
+        <ComponentGroupRef Id="lib_FoundationCShims.x86" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.x86" />
+        <ComponentGroupRef Id="lib_RegexParser.x86" />
+        <ComponentGroupRef Id="lib_StringProcessing.x86" />
+        <ComponentGroupRef Id="libBlocksRuntime.x86" />
+        <ComponentGroupRef Id="libCRT.x86" />
+        <ComponentGroupRef Id="libdispatch.x86" />
+        <ComponentGroupRef Id="libFoundation.x86" />
+        <ComponentGroupRef Id="libFoundationEssentials.x86" />
+        <ComponentGroupRef Id="libFoundationInternationalization.x86" />
+        <ComponentGroupRef Id="libFoundationNetworking.x86" />
+        <ComponentGroupRef Id="libFoundationXML.x86" />
+        <ComponentGroupRef Id="libRegexBuilder.x86" />
+        <ComponentGroupRef Id="libSwift.x86" />
+        <ComponentGroupRef Id="libswiftDispatch.x86" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.x86" />
+        <ComponentGroupRef Id="libSynchronization.x86" />
+        <ComponentGroupRef Id="libWinSDK.x86" />
+
+        <ComponentGroupRef Id="ExperimentalRegistrar.x86" />
       </Feature>
     <?endif?>
   </Package>

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -47,6 +47,9 @@
                 <Directory Id="_usr_lib_swift" Name="swift">
                   <Directory Id="_usr_lib_swift_clang" Name="clang" />
                 </Directory>
+                <Directory Id="_usr_lib_swift_static" Name="swift_static">
+                  <Directory Id="_usr_lib_swift_static_clang" Name="clang" />
+                </Directory>
               </Directory>
               <Directory Id="_usr_share" Name="share">
                 <Directory Id="_usr_share_docc" Name="docc">

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -16,6 +16,7 @@
   <String Id="VCRuntime_ProductName_x86" Value="Visual C++ Runtime (X86)" />
   <String Id="Plt_ProductName_Android" Value="Swift Android Platform Support" />
   <String Id="Plt_ProductName_Windows" Value="Swift Windows Platform Support" />
+  <String Id="Plt_ProductName_Windows_Experimental" Value="Swift Windows Platform Support [Experimental]" />
   <String Id="Rtl_ProductName_arm64" Value="Swift Windows Runtime (ARM64)" />
   <String Id="Rtl_ProductName_amd64" Value="Swift Windows Runtime (AMD64)" />
   <String Id="Rtl_ProductName_x86" Value="Swift Windows Runtime (X86)" />
@@ -26,6 +27,9 @@
   <String Id="Sdk_ProductName_Windows_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_Windows_amd64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_Windows_x86" Value="Swift Windows SDK (X86)" />
+  <String Id="Plt_ProductName_Windows_Experimental_arm64" Value="Swift Windows Platform Support (ARM64) [Experimental]" />
+  <String Id="Plt_ProductName_Windows_Experimental_amd64" Value="Swift Windows Platform Support (AMD64) [Experimental]" />
+  <String Id="Plt_ProductName_Windows_Experimental_x86" Value="Swift Windows Platform Support (X86) [Experimental]" />
   <String Id="Utl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
   <String Id="Utl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
   <String Id="Utl_ProductName_x86" Value="Swift Windows Utilities (X86)" />


### PR DESCRIPTION
This packages the experimental runtime builds to allow us to statically link against the standard library. This will be used to allow us to bootstrap the early swift-driver on Windows.