### PR TITLE
WiX: package SwiftFixIt.dll on Windows

### DIFF
--- a/platforms/Windows/cli/cli.wxs
+++ b/platforms/Windows/cli/cli.wxs
@@ -238,6 +238,9 @@
         <File Source="$(ToolchainRoot)\usr\bin\SPMBuildCore.dll" />
       </Component>
       <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\SwiftFixIt.dll" />
+      </Component>
+      <Component>
         <File Source="$(ToolchainRoot)\usr\bin\Workspace.dll" />
       </Component>
 


### PR DESCRIPTION
This is part of SPM, introduced in
swiftlang/swift-package-manager#8585. The newly minted dependency causes `swift build` to fail as it is missing the library in the installation (caught by CI at
https://github.com/thebrowsercompany/swift-build/actions/runs/14890246041).