### PR TITLE
Rename bld.msi and bld.cab to bld.asserts.msi and bld.asserts.cab

### DIFF
--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -17,7 +17,7 @@
   -->
 
   <PropertyGroup>
-    <BldUpgradeCode>{7E95DC06-7F84-4E8E-A038-8304AF0468FB}</BldUpgradeCode>
+    <BldAssertsUpgradeCode>{7E95DC06-7F84-4E8E-A038-8304AF0468FB}</BldAssertsUpgradeCode>
     <CliUpgradeCode>{87019842-3F3E-4227-B5C5-23A8EF72AD89}</CliUpgradeCode>
     <DbgUpgradeCode>{91D382AF-1E92-44DC-A4AD-AEE91C1B5160}</DbgUpgradeCode>
     <IdeUpgradeCode>{8DD91C86-D13D-490B-B06B-9522A9CF504C}</IdeUpgradeCode>
@@ -54,7 +54,7 @@
     <DefineConstants>
       $(DefineConstants);
       BundleUpgradeCode=$(BundleUpgradeCode);
-      BldUpgradeCode=$(BldUpgradeCode);
+      BldAssertsUpgradeCode=$(BldAssertsUpgradeCode);
       CliUpgradeCode=$(CliUpgradeCode);
       DbgUpgradeCode=$(DbgUpgradeCode);
       IdeUpgradeCode=$(IdeUpgradeCode);

--- a/platforms/Windows/bld/asserts/bld.asserts.wixproj
+++ b/platforms/Windows/bld/asserts/bld.asserts.wixproj
@@ -5,6 +5,7 @@
       _USR_LIB_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\clang;
       _USR_LIB_SWIFT_CLANG=$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang;
     </DefineConstants>
+    <OutputName>bld.asserts</OutputName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/platforms/Windows/bld/asserts/bld.wxs
+++ b/platforms/Windows/bld/asserts/bld.wxs
@@ -1,0 +1,3 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <?include ../bld.wxi ?>
+</Wix>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -1,18 +1,19 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
   <?define ToolchainRoot = $(ImageRoot)\Toolchains\$(ProductVersion)+Asserts?>
 
   <Package
       Language="1033"
       Manufacturer="!(loc.ManufacturerName)"
-      Name="!(loc.Bld_ProductName)"
-      UpgradeCode="$(BldUpgradeCode)"
+      Name="!(loc.BldAsserts_ProductName)"
+      UpgradeCode="$(BldAssertsUpgradeCode)"
       Version="$(NonSemVerProductVersion)"
       Scope="$(PackageScope)">
 
-    <Media Id="1" Cabinet="bld.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+    <Media Id="1" Cabinet="bld.asserts.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
 
-    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(BldUpgradeCode)" />
+    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(BldAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
     <DirectoryRef Id="_usr_include">
@@ -549,7 +550,7 @@
       </Component>
     </ComponentGroup>
 
-    <Feature Id="BuildTools" AllowAbsent="no" Title="!(loc.Bld_ProductName)">
+    <Feature Id="BuildTools" AllowAbsent="no" Title="!(loc.BldAsserts_ProductName)">
       <ComponentGroupRef Id="cmark_gfm" />
 
       <ComponentGroupRef Id="binutils" />
@@ -578,4 +579,4 @@
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
   </Package>
-</Wix>
+</Include>

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\bld\bld.wixproj" BindName="bld" />
+    <ProjectReference Include="..\bld\asserts\bld.asserts.wixproj" BindName="bld.asserts" />
     <ProjectReference Include="..\cli\cli.wixproj" BindName="cli" />
     <ProjectReference Include="..\dbg\dbg.wixproj" BindName="dbg" />
     <ProjectReference Include="..\ide\ide.wixproj" BindName="ide" />

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -82,7 +82,7 @@
       </MsiPackage>
 
       <MsiPackage
-        SourceFile="!(bindpath.bld)\bld.msi"
+        SourceFile="!(bindpath.bld.asserts)\bld.asserts.msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
       </MsiPackage>

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -216,7 +216,7 @@ Note that these GUIDs are substituted at bind time so they skip the normal valid
 
 | Property | Description |
 | -------- | ----------- |
-| BldUpgradeCode, CliUpgradeCode, DbgUpgradeCode, IdeUpgradeCode, RtlUpgradeCode, WindowsSDKUpgradeCode, AndroidSDKUpgradeCode | Upgrade codes for individual packages. Packages keep the same upgrade codes "forever" because MSI lets you specify version ranges for upgrades, which you can find in `shared/shared.wxs`. |
+| BldAssertsUpgradeCode, CliUpgradeCode, DbgUpgradeCode, IdeUpgradeCode, RtlUpgradeCode, WindowsSDKUpgradeCode, AndroidSDKUpgradeCode | Upgrade codes for individual packages. Packages keep the same upgrade codes "forever" because MSI lets you specify version ranges for upgrades, which you can find in `shared/shared.wxs`. |
 | BundleUpgradeCode | Upgrade codes for the bundle. Bundles don't support upgrade version ranges, so the bundle upgrade code must change for every minor version _and_ stay the same for the entire lifetime of that minor version (e.g., v5.10.0 through v5.10.9999). You can keep the history of upgrade codes using a condition like `Condition="'$(MajorMinorProductVersion)' == '5.10'` or just replace BundleUpgradeCode when forking to a new minor version. |
 
 

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -3,6 +3,7 @@
 <WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
   <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
   <String Id="Bld_ProductName" Value="Swift Build Tools" />
+  <String Id="BldAsserts_ProductName" Value="Swift Build Tools (Asserts)" />
   <String Id="Cli_ProductName" Value="Swift Command Line Tools" />
   <String Id="Dbg_ProductName" Value="Swift Debugging Tools" />
   <String Id="Ide_ProductName" Value="Swift IDE Integration Tools" />


### PR DESCRIPTION
Restructure our toolchain projects to reflect which toolchain variant they are carrying. In this change we are renaming `bld.msi` and `bld.cab` to `bld.assers.msi` and `bld.asserts.cab`. Also moving the `.wixproj` to variant specific folder, to make room for adding additional variants in the future. 

Renaming the properties holding upgradcode and product name for consistency. 

This change should not have any functional impact. 