### PR TITLE
WiX: Fix "Setup Progress" banner position

### DIFF
--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -85,7 +85,7 @@
         </Page>
 
         <Page Name="Progress">
-            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
+            <Label X="192" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
             <Label Name="OverallProgressPackageText" X="192" Y="89" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
             <Progressbar Name="OverallCalculatedProgressbar" X="192" Y="111" Width="-11" Height="20" />
             <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>


### PR DESCRIPTION
Fix a bug introduced in https://github.com/swiftlang/swift-installer-scripts/pull/426, where installer progress banner is off. 

here is the before and after:
![image](https://github.com/user-attachments/assets/df5bca99-8d1d-48e7-9c59-e6ffc7a8c682)


![image](https://github.com/user-attachments/assets/ae1bb486-66fa-4b01-806c-e2b4b15851b7)
