### PR TITLE
Reflect variant name in directory ids

### DIFF
--- a/platforms/Windows/bld/asserts/bld.asserts.wixproj
+++ b/platforms/Windows/bld/asserts/bld.asserts.wixproj
@@ -39,7 +39,7 @@
     <!-- FIXME(#81557) this needs to be properly staged once the sanitizers are included -->
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang">
       <ComponentGroupName>SwiftStaticClangResources_asserts</ComponentGroupName>
-      <DirectoryRefId>_usr_lib_swift_static_clang</DirectoryRefId>
+      <DirectoryRefId>toolchain_asserts_usr_lib_swift_static_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_SWIFT_STATIC_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>

--- a/platforms/Windows/bld/asserts/bld.asserts.wixproj
+++ b/platforms/Windows/bld/asserts/bld.asserts.wixproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\clang">
       <ComponentGroupName>ClangResources_asserts</ComponentGroupName>
-      <DirectoryRefId>toolchains_asserts_usr_lib_clang</DirectoryRefId>
+      <DirectoryRefId>toolchain_asserts_usr_lib_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>
@@ -27,7 +27,7 @@
   <ItemGroup>
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang">
       <ComponentGroupName>SwiftClangResources_asserts</ComponentGroupName>
-      <DirectoryRefId>toolchains_asserts_usr_lib_swift_clang</DirectoryRefId>
+      <DirectoryRefId>toolchain_asserts_usr_lib_swift_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_SWIFT_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>

--- a/platforms/Windows/bld/asserts/bld.asserts.wixproj
+++ b/platforms/Windows/bld/asserts/bld.asserts.wixproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\clang">
       <ComponentGroupName>ClangResources_asserts</ComponentGroupName>
-      <DirectoryRefId>_usr_lib_clang</DirectoryRefId>
+      <DirectoryRefId>toolchains_asserts_usr_lib_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>
@@ -27,7 +27,7 @@
   <ItemGroup>
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang">
       <ComponentGroupName>SwiftClangResources_asserts</ComponentGroupName>
-      <DirectoryRefId>_usr_lib_swift_clang</DirectoryRefId>
+      <DirectoryRefId>toolchains_asserts_usr_lib_swift_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_SWIFT_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -16,28 +16,28 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(BldAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchains_asserts_usr_include">
-      <Directory Id="toolchains_asserts_usr_include_llvm_c" Name="llvm-c" />
-      <Directory Id="toolchains_asserts_usr_include_swift" Name="swift" />
+    <DirectoryRef Id="toolchain_asserts_usr_include">
+      <Directory Id="toolchain_asserts_usr_include_llvm_c" Name="llvm-c" />
+      <Directory Id="toolchain_asserts_usr_include_swift" Name="swift" />
     </DirectoryRef>
 
-    <DirectoryRef Id="toolchains_asserts_usr_lib_swift">
-      <Directory Id="toolchains_asserts_usr_lib_swift_migrator" Name="migrator" />
-      <Directory Id="toolchains_asserts_usr_lib_swift_swiftToCxx" Name="swiftToCxx" />
+    <DirectoryRef Id="toolchain_asserts_usr_lib_swift">
+      <Directory Id="toolchain_asserts_usr_lib_swift_migrator" Name="migrator" />
+      <Directory Id="toolchain_asserts_usr_lib_swift_swiftToCxx" Name="swiftToCxx" />
     </DirectoryRef>
 
-    <DirectoryRef Id="toolchains_asserts_usr_share">
-      <Directory Id="toolchains_asserts_usr_share_clang" Name="clang" />
-      <Directory Id="toolchains_asserts_usr_share_swift" Name="swift" />
-      <Directory Id="toolchains_asserts_usr_share_doc" Name="doc">
-        <Directory Id="toolchains_asserts_usr_share_doc_swift" Name="swift">
-          <Directory Id="toolchains_asserts_usr_share_doc_swift_diagnostics" Name="diagnostics">
+    <DirectoryRef Id="toolchain_asserts_usr_share">
+      <Directory Id="toolchain_asserts_usr_share_clang" Name="clang" />
+      <Directory Id="toolchain_asserts_usr_share_swift" Name="swift" />
+      <Directory Id="toolchain_asserts_usr_share_doc" Name="doc">
+        <Directory Id="toolchain_asserts_usr_share_doc_swift" Name="swift">
+          <Directory Id="toolchain_asserts_usr_share_doc_swift_diagnostics" Name="diagnostics">
           </Directory>
         </Directory>
       </Directory>
     </DirectoryRef>
 
-    <ComponentGroup Id="cmark_gfm" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="cmark_gfm" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin/cmark-gfm.dll" />
       </Component>
@@ -46,7 +46,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="binutils" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="binutils" Directory="toolchain_asserts_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to llvm-ar.exe instead? -->
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\llvm-dlltool.exe" />
@@ -145,26 +145,26 @@
     </ComponentGroup>
 
     <ComponentGroup Id="lto">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\LTO.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\LTO.lib" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_include_llvm_c">
+      <Component Directory="toolchain_asserts_usr_include_llvm_c">
         <File Source="$(ToolchainRoot)\usr\include\llvm-c\lto.h" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="ClangFeatures" Directory="toolchains_asserts_usr_share_clang">
+    <ComponentGroup Id="ClangFeatures" Directory="toolchain_asserts_usr_share_clang">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\clang\features.json" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="clang" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="clang" Directory="toolchain_asserts_usr_bin">
       <ComponentGroupRef Id="ClangFeatures" />
 
       <!-- TODO(compnerd) can we use symbolic links to clang.exe instead? -->
@@ -195,7 +195,7 @@
       -->
     </ComponentGroup>
 
-    <ComponentGroup Id="lld" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="lld" Directory="toolchain_asserts_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to lld.exe instead? -->
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\ld.lld.exe" />
@@ -215,11 +215,11 @@
     </ComponentGroup>
 
     <ComponentGroup Id="BlocksRuntime">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\BlocksRuntime.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\BlocksRuntime.lib" />
       </Component>
 
@@ -227,18 +227,18 @@
     </ComponentGroup>
 
     <ComponentGroup Id="libdispatch">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\dispatch.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\dispatch.lib" />
       </Component>
 
       <!-- TODO(compnerd) should we install the dispatch headers? -->
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftCxx" Directory="toolchains_asserts_usr_lib_swift_swiftToCxx">
+    <ComponentGroup Id="SwiftCxx" Directory="toolchain_asserts_usr_lib_swift_swiftToCxx">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\swiftToCxx\_SwiftCxxInteroperability.h" />
       </Component>
@@ -249,27 +249,27 @@
         <File Source="$(ToolchainRoot)\usr\lib\swift\swiftToCxx\experimental-interoperability-version.json" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_include_swift">
+      <Component Directory="toolchain_asserts_usr_include_swift">
         <File Source="$(ToolchainRoot)\usr\include\swift\bridging.modulemap" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_include_swift">
+      <Component Directory="toolchain_asserts_usr_include_swift">
         <File Source="$(ToolchainRoot)\usr\include\swift\bridging" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_include_swift">
+      <Component Directory="toolchain_asserts_usr_include_swift">
         <File Source="$(ToolchainRoot)\usr\include\module.modulemap" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftDemangle">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\swiftDemangle.dll" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\swiftDemangle.lib" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftEducationalNotes" Directory="toolchains_asserts_usr_share_doc_swift_diagnostics">
+    <ComponentGroup Id="SwiftEducationalNotes" Directory="toolchain_asserts_usr_share_doc_swift_diagnostics">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\doc\swift\diagnostics\dynamic-callable-requirements.md" />
       </Component>
@@ -308,13 +308,13 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftFeatures" Directory="toolchains_asserts_usr_share_swift">
+    <ComponentGroup Id="SwiftFeatures" Directory="toolchain_asserts_usr_share_swift">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\swift\features.json" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftMigrator" Directory="toolchains_asserts_usr_lib_swift_migrator">
+    <ComponentGroup Id="SwiftMigrator" Directory="toolchain_asserts_usr_lib_swift_migrator">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\migrator\ios4.json" />
       </Component>
@@ -347,7 +347,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="swift" Directory="toolchain_asserts_usr_bin">
       <ComponentGroupRef Id="SwiftCxx" />
       <ComponentGroupRef Id="SwiftDemangle" />
       <ComponentGroupRef Id="SwiftEducationalNotes" />
@@ -372,7 +372,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftMacros" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="SwiftMacros" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\ObservationMacros.dll" />
       </Component>
@@ -381,25 +381,25 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="FoundationMacros" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="FoundationMacros" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\FoundationMacros.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="TestingMacros" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="TestingMacros" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\TestingMacros.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="argument_parser" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="argument_parser" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\ArgumentParser.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="tools_support_core" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="tools_support_core" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\TSCBasic.dll" />
       </Component>
@@ -408,7 +408,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_driver" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="swift_driver" Directory="toolchain_asserts_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to swift.exe instead? -->
       <Component>
         <File Name="swiftc.exe" Source="$(ToolchainRoot)\usr\bin\swift-driver.exe" />
@@ -432,7 +432,7 @@
       </Component>
     </ComponentGroup>
 
-   <ComponentGroup Id="compiler_swift_syntax" Directory="toolchains_asserts_usr_bin">
+   <ComponentGroup Id="compiler_swift_syntax" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\_CompilerSwiftBasicFormat.dll" />
       </Component>
@@ -474,7 +474,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_syntax" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="swift_syntax" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\SwiftBasicFormat.dll" />
       </Component>
@@ -516,7 +516,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="plugin_server" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="plugin_server" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\swift-plugin-server.exe" />
       </Component>
@@ -525,7 +525,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="mimalloc" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="mimalloc" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\mimalloc.dll" />
       </Component>
@@ -539,13 +539,13 @@
     </ComponentGroup>
 
     <ComponentGroup Id="Configuration">
-      <Component Directory="ToolchainsVersionedAsserts">
+      <Component Directory="ToolchainVersionedAsserts">
         <File Source="$(ToolchainRoot)\ToolchainInfo.plist" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="EnvironmentVariables">
-      <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="toolchains_asserts_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
+      <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="toolchain_asserts_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
         <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[_usr_bin]" />
       </Component>
     </ComponentGroup>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -539,7 +539,7 @@
     </ComponentGroup>
 
     <ComponentGroup Id="Configuration">
-      <Component Directory="ToolchainsVersioned">
+      <Component Directory="ToolchainsVersionedAsserts">
         <File Source="$(ToolchainRoot)\ToolchainInfo.plist" />
       </Component>
     </ComponentGroup>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -16,28 +16,28 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(BldAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="_usr_include">
-      <Directory Id="_usr_include_llvm_c" Name="llvm-c" />
-      <Directory Id="_usr_include_swift" Name="swift" />
+    <DirectoryRef Id="toolchains_asserts_usr_include">
+      <Directory Id="toolchains_asserts_usr_include_llvm_c" Name="llvm-c" />
+      <Directory Id="toolchains_asserts_usr_include_swift" Name="swift" />
     </DirectoryRef>
 
-    <DirectoryRef Id="_usr_lib_swift">
-      <Directory Id="_usr_lib_swift_migrator" Name="migrator" />
-      <Directory Id="_usr_lib_swift_swiftToCxx" Name="swiftToCxx" />
+    <DirectoryRef Id="toolchains_asserts_usr_lib_swift">
+      <Directory Id="toolchains_asserts_usr_lib_swift_migrator" Name="migrator" />
+      <Directory Id="toolchains_asserts_usr_lib_swift_swiftToCxx" Name="swiftToCxx" />
     </DirectoryRef>
 
-    <DirectoryRef Id="_usr_share">
-      <Directory Id="_usr_share_clang" Name="clang" />
-      <Directory Id="_usr_share_swift" Name="swift" />
-      <Directory Id="_usr_share_doc" Name="doc">
-        <Directory Id="_usr_share_doc_swift" Name="swift">
-          <Directory Id="_usr_share_doc_swift_diagnostics" Name="diagnostics">
+    <DirectoryRef Id="toolchains_asserts_usr_share">
+      <Directory Id="toolchains_asserts_usr_share_clang" Name="clang" />
+      <Directory Id="toolchains_asserts_usr_share_swift" Name="swift" />
+      <Directory Id="toolchains_asserts_usr_share_doc" Name="doc">
+        <Directory Id="toolchains_asserts_usr_share_doc_swift" Name="swift">
+          <Directory Id="toolchains_asserts_usr_share_doc_swift_diagnostics" Name="diagnostics">
           </Directory>
         </Directory>
       </Directory>
     </DirectoryRef>
 
-    <ComponentGroup Id="cmark_gfm" Directory="_usr_bin">
+    <ComponentGroup Id="cmark_gfm" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin/cmark-gfm.dll" />
       </Component>
@@ -46,7 +46,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="binutils" Directory="_usr_bin">
+    <ComponentGroup Id="binutils" Directory="toolchains_asserts_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to llvm-ar.exe instead? -->
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\llvm-dlltool.exe" />
@@ -145,26 +145,26 @@
     </ComponentGroup>
 
     <ComponentGroup Id="lto">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\LTO.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\LTO.lib" />
       </Component>
 
-      <Component Directory="_usr_include_llvm_c">
+      <Component Directory="toolchains_asserts_usr_include_llvm_c">
         <File Source="$(ToolchainRoot)\usr\include\llvm-c\lto.h" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="ClangFeatures" Directory="_usr_share_clang">
+    <ComponentGroup Id="ClangFeatures" Directory="toolchains_asserts_usr_share_clang">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\clang\features.json" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="clang" Directory="_usr_bin">
+    <ComponentGroup Id="clang" Directory="toolchains_asserts_usr_bin">
       <ComponentGroupRef Id="ClangFeatures" />
 
       <!-- TODO(compnerd) can we use symbolic links to clang.exe instead? -->
@@ -195,7 +195,7 @@
       -->
     </ComponentGroup>
 
-    <ComponentGroup Id="lld" Directory="_usr_bin">
+    <ComponentGroup Id="lld" Directory="toolchains_asserts_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to lld.exe instead? -->
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\ld.lld.exe" />
@@ -215,11 +215,11 @@
     </ComponentGroup>
 
     <ComponentGroup Id="BlocksRuntime">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\BlocksRuntime.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\BlocksRuntime.lib" />
       </Component>
 
@@ -227,18 +227,18 @@
     </ComponentGroup>
 
     <ComponentGroup Id="libdispatch">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\dispatch.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\dispatch.lib" />
       </Component>
 
       <!-- TODO(compnerd) should we install the dispatch headers? -->
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftCxx" Directory="_usr_lib_swift_swiftToCxx">
+    <ComponentGroup Id="SwiftCxx" Directory="toolchains_asserts_usr_lib_swift_swiftToCxx">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\swiftToCxx\_SwiftCxxInteroperability.h" />
       </Component>
@@ -249,27 +249,27 @@
         <File Source="$(ToolchainRoot)\usr\lib\swift\swiftToCxx\experimental-interoperability-version.json" />
       </Component>
 
-      <Component Directory="_usr_include_swift">
+      <Component Directory="toolchains_asserts_usr_include_swift">
         <File Source="$(ToolchainRoot)\usr\include\swift\bridging.modulemap" />
       </Component>
-      <Component Directory="_usr_include_swift">
+      <Component Directory="toolchains_asserts_usr_include_swift">
         <File Source="$(ToolchainRoot)\usr\include\swift\bridging" />
       </Component>
-      <Component Directory="_usr_include_swift">
+      <Component Directory="toolchains_asserts_usr_include_swift">
         <File Source="$(ToolchainRoot)\usr\include\module.modulemap" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftDemangle">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\swiftDemangle.dll" />
       </Component>
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\swiftDemangle.lib" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftEducationalNotes" Directory="_usr_share_doc_swift_diagnostics">
+    <ComponentGroup Id="SwiftEducationalNotes" Directory="toolchains_asserts_usr_share_doc_swift_diagnostics">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\doc\swift\diagnostics\dynamic-callable-requirements.md" />
       </Component>
@@ -308,13 +308,13 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftFeatures" Directory="_usr_share_swift">
+    <ComponentGroup Id="SwiftFeatures" Directory="toolchains_asserts_usr_share_swift">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\swift\features.json" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftMigrator" Directory="_usr_lib_swift_migrator">
+    <ComponentGroup Id="SwiftMigrator" Directory="toolchains_asserts_usr_lib_swift_migrator">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\migrator\ios4.json" />
       </Component>
@@ -347,7 +347,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift" Directory="_usr_bin">
+    <ComponentGroup Id="swift" Directory="toolchains_asserts_usr_bin">
       <ComponentGroupRef Id="SwiftCxx" />
       <ComponentGroupRef Id="SwiftDemangle" />
       <ComponentGroupRef Id="SwiftEducationalNotes" />
@@ -372,7 +372,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftMacros" Directory="_usr_bin">
+    <ComponentGroup Id="SwiftMacros" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\ObservationMacros.dll" />
       </Component>
@@ -381,25 +381,25 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="FoundationMacros" Directory="_usr_bin">
+    <ComponentGroup Id="FoundationMacros" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\FoundationMacros.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="TestingMacros" Directory="_usr_bin">
+    <ComponentGroup Id="TestingMacros" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\TestingMacros.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="argument_parser" Directory="_usr_bin">
+    <ComponentGroup Id="argument_parser" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\ArgumentParser.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="tools_support_core" Directory="_usr_bin">
+    <ComponentGroup Id="tools_support_core" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\TSCBasic.dll" />
       </Component>
@@ -408,7 +408,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_driver" Directory="_usr_bin">
+    <ComponentGroup Id="swift_driver" Directory="toolchains_asserts_usr_bin">
       <!-- TODO(compnerd) can we use symbolic links to swift.exe instead? -->
       <Component>
         <File Name="swiftc.exe" Source="$(ToolchainRoot)\usr\bin\swift-driver.exe" />
@@ -432,7 +432,7 @@
       </Component>
     </ComponentGroup>
 
-   <ComponentGroup Id="compiler_swift_syntax" Directory="_usr_bin">
+   <ComponentGroup Id="compiler_swift_syntax" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\_CompilerSwiftBasicFormat.dll" />
       </Component>
@@ -474,7 +474,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_syntax" Directory="_usr_bin">
+    <ComponentGroup Id="swift_syntax" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\SwiftBasicFormat.dll" />
       </Component>
@@ -516,7 +516,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="plugin_server" Directory="_usr_bin">
+    <ComponentGroup Id="plugin_server" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\swift-plugin-server.exe" />
       </Component>
@@ -525,7 +525,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="mimalloc" Directory="_usr_bin">
+    <ComponentGroup Id="mimalloc" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\mimalloc.dll" />
       </Component>
@@ -545,7 +545,7 @@
     </ComponentGroup>
 
     <ComponentGroup Id="EnvironmentVariables">
-      <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
+      <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="toolchains_asserts_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
         <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[_usr_bin]" />
       </Component>
     </ComponentGroup>

--- a/platforms/Windows/cli/asserts/cli.asserts.wixproj
+++ b/platforms/Windows/cli/asserts/cli.asserts.wixproj
@@ -17,7 +17,7 @@
   <ItemGroup Condition=" '$(INCLUDE_SWIFT_DOCC)' == 'True' ">
     <HarvestDirectory Include="$(SWIFT_DOCC_RENDER_ARTIFACT_ROOT)\dist">
       <ComponentGroupName>DocCRender_asserts</ComponentGroupName>
-      <DirectoryRefId>_usr_share_docc_render</DirectoryRefId>
+      <DirectoryRefId>toolchains_asserts_usr_share_docc_render</DirectoryRefId>
       <PreprocessorVariable>var.SWIFT_DOCC_RENDER_ARTIFACT_ROOT_DIST</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>

--- a/platforms/Windows/cli/asserts/cli.asserts.wixproj
+++ b/platforms/Windows/cli/asserts/cli.asserts.wixproj
@@ -17,7 +17,7 @@
   <ItemGroup Condition=" '$(INCLUDE_SWIFT_DOCC)' == 'True' ">
     <HarvestDirectory Include="$(SWIFT_DOCC_RENDER_ARTIFACT_ROOT)\dist">
       <ComponentGroupName>DocCRender_asserts</ComponentGroupName>
-      <DirectoryRefId>toolchains_asserts_usr_share_docc_render</DirectoryRefId>
+      <DirectoryRefId>toolchain_asserts_usr_share_docc_render</DirectoryRefId>
       <PreprocessorVariable>var.SWIFT_DOCC_RENDER_ARTIFACT_ROOT_DIST</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
       <SuppressRegistry>true</SuppressRegistry>

--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -16,33 +16,33 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(CliAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="_usr_include">
-      <Directory Id="_usr_include__InternalSwiftScan" Name="_InternalSwiftScan" />
-      <Directory Id="_usr_include_clang_c" Name="clang-c" />
-      <Directory Id="_usr_include_indexstore" Name="indexstore" />
+    <DirectoryRef Id="toolchains_asserts_usr_include">
+      <Directory Id="toolchains_asserts_usr_include__InternalSwiftScan" Name="_InternalSwiftScan" />
+      <Directory Id="toolchains_asserts_usr_include_clang_c" Name="clang-c" />
+      <Directory Id="toolchains_asserts_usr_include_indexstore" Name="indexstore" />
     </DirectoryRef>
 
-    <DirectoryRef Id="_usr_lib_swift">
+    <DirectoryRef Id="toolchains_asserts_usr_lib_swift">
       <Directory Name="pm">
-        <Directory Id="_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI" />
-        <Directory Id="_usr_lib_swift_pm_PluginAPI" Name="PluginAPI" />
+        <Directory Id="toolchains_asserts_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI" />
+        <Directory Id="toolchains_asserts_usr_lib_swift_pm_PluginAPI" Name="PluginAPI" />
       </Directory>
     </DirectoryRef>
 
-    <DirectoryRef Id="_usr_share">
-      <Directory Id="_usr_share_pm" Name="pm">
-        <Directory Id="_usr_share_pm_SWBAndroidPlatform" Name="SwiftBuild_SWBAndroidPlatform.resources" />
-        <Directory Id="_usr_share_pm_SWBApplePlatform" Name="SwiftBuild_SWBApplePlatform.resources" />
-        <Directory Id="_usr_share_pm_SWBCore" Name="SwiftBuild_SWBCore.resources" />
-        <Directory Id="_usr_share_pm_SWBGenericUnixPlatform" Name="SwiftBuild_SWBGenericUnixPlatform.resources" />
-        <Directory Id="_usr_share_pm_SWBQNXPlatform" Name="SwiftBuild_SWBQNXPlatform.resources" />
-        <Directory Id="_usr_share_pm_SWBUniversalPlatform" Name="SwiftBuild_SWBUniversalPlatform.resources" />
-        <Directory Id="_usr_share_pm_SWBWebAssemblyPlatform" Name="SwiftBuild_SWBWebAssemblyPlatform.resources" />
-        <Directory Id="_usr_share_pm_SWBWindowsPlatform" Name="SwiftBuild_SWBWindowsPlatform.resources" />
+    <DirectoryRef Id="toolchains_asserts_usr_share">
+      <Directory Id="toolchains_asserts_usr_share_pm" Name="pm">
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBAndroidPlatform" Name="SwiftBuild_SWBAndroidPlatform.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBApplePlatform" Name="SwiftBuild_SWBApplePlatform.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBCore" Name="SwiftBuild_SWBCore.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBGenericUnixPlatform" Name="SwiftBuild_SWBGenericUnixPlatform.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBQNXPlatform" Name="SwiftBuild_SWBQNXPlatform.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBUniversalPlatform" Name="SwiftBuild_SWBUniversalPlatform.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBWebAssemblyPlatform" Name="SwiftBuild_SWBWebAssemblyPlatform.resources" />
+        <Directory Id="toolchains_asserts_usr_share_pm_SWBWindowsPlatform" Name="SwiftBuild_SWBWindowsPlatform.resources" />
       </Directory>
     </DirectoryRef>
 
-    <ComponentGroup Id="clang" Directory="_usr_bin">
+    <ComponentGroup Id="clang" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\clang-format.exe" />
       </Component>
@@ -56,12 +56,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="libclang" Directory="_usr_include_clang_c">
-      <Component Directory="_usr_bin">
+    <ComponentGroup Id="libclang" Directory="toolchains_asserts_usr_include_clang_c">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\libclang.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\libclang.lib" />
       </Component>
 
@@ -94,12 +94,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="IndexStore" Directory="_usr_include_indexstore">
-      <Component Directory="_usr_bin">
+    <ComponentGroup Id="IndexStore" Directory="toolchains_asserts_usr_include_indexstore">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\libIndexStore.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\libIndexStore.lib" />
       </Component>
 
@@ -111,12 +111,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="_InternalSwiftScan" Directory="_usr_include__InternalSwiftScan">
-      <Component Directory="_usr_bin">
+    <ComponentGroup Id="_InternalSwiftScan" Directory="toolchains_asserts_usr_include__InternalSwiftScan">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\_InternalSwiftScan.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\swift\windows\_InternalSwiftScan.lib" />
       </Component>
 
@@ -131,7 +131,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="collections" Directory="_usr_bin">
+    <ComponentGroup Id="collections" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\Collections.dll" />
       </Component>
@@ -146,13 +146,13 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="llbuild" Directory="_usr_bin">
+    <ComponentGroup Id="llbuild" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\llbuildSwift.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CompilerPluginSupport" Directory="_usr_lib_swift_pm_ManifestAPI">
+    <ComponentGroup Id="CompilerPluginSupport" Directory="toolchains_asserts_usr_lib_swift_pm_ManifestAPI">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" />
       </Component>
@@ -167,7 +167,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="PackageDescription" Directory="_usr_lib_swift_pm_ManifestAPI">
+    <ComponentGroup Id="PackageDescription" Directory="toolchains_asserts_usr_lib_swift_pm_ManifestAPI">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" />
       </Component>
@@ -182,7 +182,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="PackagePlugin" Directory="_usr_lib_swift_pm_PluginAPI">
+    <ComponentGroup Id="PackagePlugin" Directory="toolchains_asserts_usr_lib_swift_pm_PluginAPI">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" />
       </Component>
@@ -197,12 +197,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SWBAndroidPlatformResources" Directory="_usr_share_pm_SWBAndroidPlatform">
+    <ComponentGroup Id="SWBAndroidPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBAndroidPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBAndroidPlatform.resources\Android.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBApplePlatformResources" Directory="_usr_share_pm_SWBApplePlatform">
+    <ComponentGroup Id="SWBApplePlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBApplePlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\AppIntentsMetadata.xcspec" />
       </Component>
@@ -414,7 +414,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\xrOSSimulator.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBCoreResources" Directory="_usr_share_pm_SWBCore">
+    <ComponentGroup Id="SWBCoreResources" Directory="toolchains_asserts_usr_share_pm_SWBCore">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBCore.resources\CoreBuildSystem.xcspec" />
       </Component>
@@ -425,7 +425,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBCore.resources\NativeBuildSystem.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBGenericUnixPlatformResources" Directory="_usr_share_pm_SWBGenericUnixPlatform">
+    <ComponentGroup Id="SWBGenericUnixPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBGenericUnixPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBGenericUnixPlatform.resources\Unix.xcspec" />
       </Component>
@@ -439,7 +439,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBGenericUnixPlatform.resources\UnixLibtool.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBQNXPlatformResources" Directory="_usr_share_pm_SWBQNXPlatform">
+    <ComponentGroup Id="SWBQNXPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBQNXPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBQNXPlatform.resources\QNX.xcspec" />
       </Component>
@@ -453,7 +453,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBQNXPlatform.resources\QNXLibtool.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBUniversalPlatformResources" Directory="_usr_share_pm_SWBUniversalPlatform">
+    <ComponentGroup Id="SWBUniversalPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBUniversalPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBUniversalPlatform.resources\BuiltInBuildRules.xcbuildrules" />
       </Component>
@@ -545,7 +545,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBUniversalPlatform.resources\swift-stdlib-tool.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBWebAssemblyPlatformResources" Directory="_usr_share_pm_SWBWebAssemblyPlatform">
+    <ComponentGroup Id="SWBWebAssemblyPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBWebAssemblyPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWebAssemblyPlatform.resources\WasmCompile.xcspec" />
       </Component>
@@ -559,7 +559,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWebAssemblyPlatform.resources\WebAssembly.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBWindowsPlatformResources" Directory="_usr_share_pm_SWBWindowsPlatform">
+    <ComponentGroup Id="SWBWindowsPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBWindowsPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWindowsPlatform.resources\Windows.xcspec" />
       </Component>
@@ -574,7 +574,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftBuild" Directory="_usr_bin">
+    <ComponentGroup Id="SwiftBuild" Directory="toolchains_asserts_usr_bin">
       <ComponentGroupRef Id="SWBAndroidPlatformResources" />
       <ComponentGroupRef Id="SWBApplePlatformResources" />
       <ComponentGroupRef Id="SWBCoreResources" />
@@ -655,7 +655,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="package_manager" Directory="_usr_bin">
+    <ComponentGroup Id="package_manager" Directory="toolchains_asserts_usr_bin">
       <ComponentGroupRef Id="CompilerPluginSupport" />
       <ComponentGroupRef Id="PackageDescription" />
       <ComponentGroupRef Id="PackagePlugin" />
@@ -719,7 +719,7 @@
       <!-- FIXME(compnerd) we should include the SPM import libraries -->
     </ComponentGroup>
 
-    <ComponentGroup Id="DocC" Directory="_usr_bin">
+    <ComponentGroup Id="DocC" Directory="toolchains_asserts_usr_bin">
       <?if $(INCLUDE_SWIFT_DOCC) = True?>
         <Component>
           <File Source="$(SWIFT_DOCC_BUILD)\docc.exe" />
@@ -727,7 +727,7 @@
       <?endif?>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_format" Directory="_usr_bin">
+    <ComponentGroup Id="swift_format" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\swift-format.exe" />
       </Component>

--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -16,33 +16,33 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(CliAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchains_asserts_usr_include">
-      <Directory Id="toolchains_asserts_usr_include__InternalSwiftScan" Name="_InternalSwiftScan" />
-      <Directory Id="toolchains_asserts_usr_include_clang_c" Name="clang-c" />
-      <Directory Id="toolchains_asserts_usr_include_indexstore" Name="indexstore" />
+    <DirectoryRef Id="toolchain_asserts_usr_include">
+      <Directory Id="toolchain_asserts_usr_include__InternalSwiftScan" Name="_InternalSwiftScan" />
+      <Directory Id="toolchain_asserts_usr_include_clang_c" Name="clang-c" />
+      <Directory Id="toolchain_asserts_usr_include_indexstore" Name="indexstore" />
     </DirectoryRef>
 
-    <DirectoryRef Id="toolchains_asserts_usr_lib_swift">
+    <DirectoryRef Id="toolchain_asserts_usr_lib_swift">
       <Directory Name="pm">
-        <Directory Id="toolchains_asserts_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI" />
-        <Directory Id="toolchains_asserts_usr_lib_swift_pm_PluginAPI" Name="PluginAPI" />
+        <Directory Id="toolchain_asserts_usr_lib_swift_pm_ManifestAPI" Name="ManifestAPI" />
+        <Directory Id="toolchain_asserts_usr_lib_swift_pm_PluginAPI" Name="PluginAPI" />
       </Directory>
     </DirectoryRef>
 
-    <DirectoryRef Id="toolchains_asserts_usr_share">
-      <Directory Id="toolchains_asserts_usr_share_pm" Name="pm">
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBAndroidPlatform" Name="SwiftBuild_SWBAndroidPlatform.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBApplePlatform" Name="SwiftBuild_SWBApplePlatform.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBCore" Name="SwiftBuild_SWBCore.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBGenericUnixPlatform" Name="SwiftBuild_SWBGenericUnixPlatform.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBQNXPlatform" Name="SwiftBuild_SWBQNXPlatform.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBUniversalPlatform" Name="SwiftBuild_SWBUniversalPlatform.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBWebAssemblyPlatform" Name="SwiftBuild_SWBWebAssemblyPlatform.resources" />
-        <Directory Id="toolchains_asserts_usr_share_pm_SWBWindowsPlatform" Name="SwiftBuild_SWBWindowsPlatform.resources" />
+    <DirectoryRef Id="toolchain_asserts_usr_share">
+      <Directory Id="toolchain_asserts_usr_share_pm" Name="pm">
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBAndroidPlatform" Name="SwiftBuild_SWBAndroidPlatform.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBApplePlatform" Name="SwiftBuild_SWBApplePlatform.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBCore" Name="SwiftBuild_SWBCore.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBGenericUnixPlatform" Name="SwiftBuild_SWBGenericUnixPlatform.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBQNXPlatform" Name="SwiftBuild_SWBQNXPlatform.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBUniversalPlatform" Name="SwiftBuild_SWBUniversalPlatform.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBWebAssemblyPlatform" Name="SwiftBuild_SWBWebAssemblyPlatform.resources" />
+        <Directory Id="toolchain_asserts_usr_share_pm_SWBWindowsPlatform" Name="SwiftBuild_SWBWindowsPlatform.resources" />
       </Directory>
     </DirectoryRef>
 
-    <ComponentGroup Id="clang" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="clang" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\clang-format.exe" />
       </Component>
@@ -56,12 +56,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="libclang" Directory="toolchains_asserts_usr_include_clang_c">
-      <Component Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="libclang" Directory="toolchain_asserts_usr_include_clang_c">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\libclang.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\libclang.lib" />
       </Component>
 
@@ -94,12 +94,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="IndexStore" Directory="toolchains_asserts_usr_include_indexstore">
-      <Component Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="IndexStore" Directory="toolchain_asserts_usr_include_indexstore">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\libIndexStore.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\libIndexStore.lib" />
       </Component>
 
@@ -111,12 +111,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="_InternalSwiftScan" Directory="toolchains_asserts_usr_include__InternalSwiftScan">
-      <Component Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="_InternalSwiftScan" Directory="toolchain_asserts_usr_include__InternalSwiftScan">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\_InternalSwiftScan.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\swift\windows\_InternalSwiftScan.lib" />
       </Component>
 
@@ -131,7 +131,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="collections" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="collections" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\Collections.dll" />
       </Component>
@@ -146,13 +146,13 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="llbuild" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="llbuild" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\llbuildSwift.dll" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="CompilerPluginSupport" Directory="toolchains_asserts_usr_lib_swift_pm_ManifestAPI">
+    <ComponentGroup Id="CompilerPluginSupport" Directory="toolchain_asserts_usr_lib_swift_pm_ManifestAPI">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\pm\ManifestAPI\CompilerPluginSupport.dll" />
       </Component>
@@ -167,7 +167,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="PackageDescription" Directory="toolchains_asserts_usr_lib_swift_pm_ManifestAPI">
+    <ComponentGroup Id="PackageDescription" Directory="toolchain_asserts_usr_lib_swift_pm_ManifestAPI">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\pm\ManifestAPI\PackageDescription.dll" />
       </Component>
@@ -182,7 +182,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="PackagePlugin" Directory="toolchains_asserts_usr_lib_swift_pm_PluginAPI">
+    <ComponentGroup Id="PackagePlugin" Directory="toolchain_asserts_usr_lib_swift_pm_PluginAPI">
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\pm\PluginAPI\PackagePlugin.dll" />
       </Component>
@@ -197,12 +197,12 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SWBAndroidPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBAndroidPlatform">
+    <ComponentGroup Id="SWBAndroidPlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBAndroidPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBAndroidPlatform.resources\Android.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBApplePlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBApplePlatform">
+    <ComponentGroup Id="SWBApplePlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBApplePlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\AppIntentsMetadata.xcspec" />
       </Component>
@@ -414,7 +414,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\xrOSSimulator.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBCoreResources" Directory="toolchains_asserts_usr_share_pm_SWBCore">
+    <ComponentGroup Id="SWBCoreResources" Directory="toolchain_asserts_usr_share_pm_SWBCore">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBCore.resources\CoreBuildSystem.xcspec" />
       </Component>
@@ -425,7 +425,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBCore.resources\NativeBuildSystem.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBGenericUnixPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBGenericUnixPlatform">
+    <ComponentGroup Id="SWBGenericUnixPlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBGenericUnixPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBGenericUnixPlatform.resources\Unix.xcspec" />
       </Component>
@@ -439,7 +439,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBGenericUnixPlatform.resources\UnixLibtool.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBQNXPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBQNXPlatform">
+    <ComponentGroup Id="SWBQNXPlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBQNXPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBQNXPlatform.resources\QNX.xcspec" />
       </Component>
@@ -453,7 +453,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBQNXPlatform.resources\QNXLibtool.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBUniversalPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBUniversalPlatform">
+    <ComponentGroup Id="SWBUniversalPlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBUniversalPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBUniversalPlatform.resources\BuiltInBuildRules.xcbuildrules" />
       </Component>
@@ -545,7 +545,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBUniversalPlatform.resources\swift-stdlib-tool.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBWebAssemblyPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBWebAssemblyPlatform">
+    <ComponentGroup Id="SWBWebAssemblyPlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBWebAssemblyPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWebAssemblyPlatform.resources\WasmCompile.xcspec" />
       </Component>
@@ -559,7 +559,7 @@
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWebAssemblyPlatform.resources\WebAssembly.xcspec" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="SWBWindowsPlatformResources" Directory="toolchains_asserts_usr_share_pm_SWBWindowsPlatform">
+    <ComponentGroup Id="SWBWindowsPlatformResources" Directory="toolchain_asserts_usr_share_pm_SWBWindowsPlatform">
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWindowsPlatform.resources\Windows.xcspec" />
       </Component>
@@ -574,7 +574,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="SwiftBuild" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="SwiftBuild" Directory="toolchain_asserts_usr_bin">
       <ComponentGroupRef Id="SWBAndroidPlatformResources" />
       <ComponentGroupRef Id="SWBApplePlatformResources" />
       <ComponentGroupRef Id="SWBCoreResources" />
@@ -655,7 +655,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="package_manager" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="package_manager" Directory="toolchain_asserts_usr_bin">
       <ComponentGroupRef Id="CompilerPluginSupport" />
       <ComponentGroupRef Id="PackageDescription" />
       <ComponentGroupRef Id="PackagePlugin" />
@@ -719,7 +719,7 @@
       <!-- FIXME(compnerd) we should include the SPM import libraries -->
     </ComponentGroup>
 
-    <ComponentGroup Id="DocC" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="DocC" Directory="toolchain_asserts_usr_bin">
       <?if $(INCLUDE_SWIFT_DOCC) = True?>
         <Component>
           <File Source="$(SWIFT_DOCC_BUILD)\docc.exe" />
@@ -727,7 +727,7 @@
       <?endif?>
     </ComponentGroup>
 
-    <ComponentGroup Id="swift_format" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="swift_format" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\swift-format.exe" />
       </Component>

--- a/platforms/Windows/dbg/dbg.wxi
+++ b/platforms/Windows/dbg/dbg.wxi
@@ -16,117 +16,117 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(DbgAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchains_asserts_usr_include">
-      <Directory Id="toolchains_asserts_usr_include__InternalSwiftStaticMirror" Name="_InternalSwiftStaticMirror" />
+    <DirectoryRef Id="toolchain_asserts_usr_include">
+      <Directory Id="toolchain_asserts_usr_include__InternalSwiftStaticMirror" Name="_InternalSwiftStaticMirror" />
     </DirectoryRef>
 
-    <DirectoryRef Id="toolchains_asserts_usr_lib">
+    <DirectoryRef Id="toolchain_asserts_usr_lib">
       <Directory Name="site-packages">
-        <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb" Name="lldb">
-          <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb_formatters" Name="formatters">
-            <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp" />
+        <Directory Id="toolchain_asserts_usr_lib_site_packages_lldb" Name="lldb">
+          <Directory Id="toolchain_asserts_usr_lib_site_packages_lldb_formatters" Name="formatters">
+            <Directory Id="toolchain_asserts_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp" />
           </Directory>
-          <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb_utils" Name="utils" />
+          <Directory Id="toolchain_asserts_usr_lib_site_packages_lldb_utils" Name="utils" />
         </Directory>
       </Directory>
     </DirectoryRef>
 
     <ComponentGroup Id="LLDB">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\lldb.exe" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\liblldb.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\liblldb.lib" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\__init__.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\_lldb.pyd" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\embedded_interpreter.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\lldb-argdumper.exe" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\Logger.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\__init__.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cache.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\metrics.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\synth.py" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters_cpp">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters_cpp">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_formatters_cpp">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_utils">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_utils">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\utils\__init__.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_utils">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_utils">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\utils\in_call_stack.py" />
       </Component>
-      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_utils">
+      <Component Directory="toolchain_asserts_usr_lib_site_packages_lldb_utils">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\utils\symbolication.py" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="LLDBServer">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\lldb-server.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftREPL">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\repl_swift.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftSynthesizeInterface">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\swift-synthesize-interface.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftInspect">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\swift-inspect.exe" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="_InternalSwiftStaticMirror" Directory="toolchains_asserts_usr_include__InternalSwiftStaticMirror">
-      <Component Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="_InternalSwiftStaticMirror" Directory="toolchain_asserts_usr_include__InternalSwiftStaticMirror">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\_InternalSwiftStaticMirror.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\swift\windows\_InternalSwiftStaticMirror.lib" />
       </Component>
 

--- a/platforms/Windows/dbg/dbg.wxi
+++ b/platforms/Windows/dbg/dbg.wxi
@@ -16,117 +16,117 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(DbgAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="_usr_include">
-      <Directory Id="_usr_include__InternalSwiftStaticMirror" Name="_InternalSwiftStaticMirror" />
+    <DirectoryRef Id="toolchains_asserts_usr_include">
+      <Directory Id="toolchains_asserts_usr_include__InternalSwiftStaticMirror" Name="_InternalSwiftStaticMirror" />
     </DirectoryRef>
 
-    <DirectoryRef Id="_usr_lib">
+    <DirectoryRef Id="toolchains_asserts_usr_lib">
       <Directory Name="site-packages">
-        <Directory Id="_usr_lib_site_packages_lldb" Name="lldb">
-          <Directory Id="_usr_lib_site_packages_lldb_formatters" Name="formatters">
-            <Directory Id="_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp" />
+        <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb" Name="lldb">
+          <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb_formatters" Name="formatters">
+            <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp" Name="cpp" />
           </Directory>
-          <Directory Id="_usr_lib_site_packages_lldb_utils" Name="utils" />
+          <Directory Id="toolchains_asserts_usr_lib_site_packages_lldb_utils" Name="utils" />
         </Directory>
       </Directory>
     </DirectoryRef>
 
     <ComponentGroup Id="LLDB">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\lldb.exe" />
       </Component>
 
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\liblldb.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\liblldb.lib" />
       </Component>
 
-      <Component Directory="_usr_lib_site_packages_lldb">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\__init__.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\_lldb.pyd" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\embedded_interpreter.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\lldb-argdumper.exe" />
       </Component>
 
-      <Component Directory="_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\Logger.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\__init__.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\attrib_fromdict.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cache.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\metrics.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\synth.py" />
       </Component>
 
-      <Component Directory="_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cpp\__init__.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cpp\gnu_libstdcpp.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_formatters_cpp">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_formatters_cpp">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\formatters\cpp\libcxx.py" />
       </Component>
 
-      <Component Directory="_usr_lib_site_packages_lldb_utils">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_utils">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\utils\__init__.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_utils">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_utils">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\utils\in_call_stack.py" />
       </Component>
-      <Component Directory="_usr_lib_site_packages_lldb_utils">
+      <Component Directory="toolchains_asserts_usr_lib_site_packages_lldb_utils">
         <File Source="$(ToolchainRoot)\usr\lib\site-packages\lldb\utils\symbolication.py" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="LLDBServer">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\lldb-server.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftREPL">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\repl_swift.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftSynthesizeInterface">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\swift-synthesize-interface.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftInspect">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\swift-inspect.exe" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="_InternalSwiftStaticMirror" Directory="_usr_include__InternalSwiftStaticMirror">
-      <Component Directory="_usr_bin">
+    <ComponentGroup Id="_InternalSwiftStaticMirror" Directory="toolchains_asserts_usr_include__InternalSwiftStaticMirror">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\_InternalSwiftStaticMirror.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\swift\windows\_InternalSwiftStaticMirror.lib" />
       </Component>
 

--- a/platforms/Windows/ide/ide.wxi
+++ b/platforms/Windows/ide/ide.wxi
@@ -16,45 +16,45 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(IdeAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="_usr_include">
-      <Directory Id="_usr_include_SourceKit" Name="SourceKit" />
+    <DirectoryRef Id="toolchains_asserts_usr_include">
+      <Directory Id="toolchains_asserts_usr_include_SourceKit" Name="SourceKit" />
     </DirectoryRef>
 
-    <ComponentGroup Id="clangd" Directory="_usr_bin">
+    <ComponentGroup Id="clangd" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\clangd.exe" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="lldb" Directory="_usr_bin">
+    <ComponentGroup Id="lldb" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\lldb-dap.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="sourcekitd">
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\sourcekitdInProc.dll" />
       </Component>
 
-      <Component Directory="_usr_lib">
+      <Component Directory="toolchains_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\sourcekitdInProc.lib" />
       </Component>
 
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\lib\SwiftSourceKitPlugin.dll" />
       </Component>
 
-      <Component Directory="_usr_bin">
+      <Component Directory="toolchains_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\lib\SwiftSourceKitClientPlugin.dll" />
       </Component>
 
-      <Component Directory="_usr_include_SourceKit">
+      <Component Directory="toolchains_asserts_usr_include_SourceKit">
         <File Source="$(ToolchainRoot)\usr\include\SourceKit\sourcekitd.h" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="lsp" Directory="_usr_bin">
+    <ComponentGroup Id="lsp" Directory="toolchains_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\sourcekit-lsp.exe" />
       </Component>

--- a/platforms/Windows/ide/ide.wxi
+++ b/platforms/Windows/ide/ide.wxi
@@ -16,45 +16,45 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(IdeAssertsUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchains_asserts_usr_include">
-      <Directory Id="toolchains_asserts_usr_include_SourceKit" Name="SourceKit" />
+    <DirectoryRef Id="toolchain_asserts_usr_include">
+      <Directory Id="toolchain_asserts_usr_include_SourceKit" Name="SourceKit" />
     </DirectoryRef>
 
-    <ComponentGroup Id="clangd" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="clangd" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\clangd.exe" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="lldb" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="lldb" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\lldb-dap.exe" />
       </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="sourcekitd">
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\bin\sourcekitdInProc.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_lib">
+      <Component Directory="toolchain_asserts_usr_lib">
         <File Source="$(ToolchainRoot)\usr\lib\sourcekitdInProc.lib" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\lib\SwiftSourceKitPlugin.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_bin">
+      <Component Directory="toolchain_asserts_usr_bin">
         <File Source="$(ToolchainRoot)\usr\lib\SwiftSourceKitClientPlugin.dll" />
       </Component>
 
-      <Component Directory="toolchains_asserts_usr_include_SourceKit">
+      <Component Directory="toolchain_asserts_usr_include_SourceKit">
         <File Source="$(ToolchainRoot)\usr\include\SourceKit\sourcekitd.h" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="lsp" Directory="toolchains_asserts_usr_bin">
+    <ComponentGroup Id="lsp" Directory="toolchain_asserts_usr_bin">
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\sourcekit-lsp.exe" />
       </Component>

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -47,8 +47,8 @@
                 <Directory Id="toolchain_asserts_usr_lib_swift" Name="swift">
                   <Directory Id="toolchain_asserts_usr_lib_swift_clang" Name="clang" />
                 </Directory>
-                <Directory Id="_usr_lib_swift_static" Name="swift_static">
-                  <Directory Id="_usr_lib_swift_static_clang" Name="clang" />
+                <Directory Id="toolchain_asserts_usr_lib_swift_static" Name="swift_static">
+                  <Directory Id="toolchain_asserts_usr_lib_swift_static_clang" Name="clang" />
                 </Directory>
               </Directory>
               <Directory Id="toolchain_asserts_usr_share" Name="share">

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -39,21 +39,21 @@
     <DirectoryRef Id="INSTALLROOT">
         <Directory Name="Toolchains">
           <Directory Id="ToolchainsVersionedAsserts" Name="$(ProductVersion)+Asserts">
-            <Directory Id="_usr" Name="usr">
-              <Directory Id="_usr_bin" Name="bin" />
-              <Directory Id="_usr_include" Name="include" />
-              <Directory Id="_usr_lib" Name="lib">
-                <Directory Id="_usr_lib_clang" Name="clang" />
-                <Directory Id="_usr_lib_swift" Name="swift">
-                  <Directory Id="_usr_lib_swift_clang" Name="clang" />
+            <Directory Id="toolchains_asserts_usr" Name="usr">
+              <Directory Id="toolchains_asserts_usr_bin" Name="bin" />
+              <Directory Id="toolchains_asserts_usr_include" Name="include" />
+              <Directory Id="toolchains_asserts_usr_lib" Name="lib">
+                <Directory Id="toolchains_asserts_usr_lib_clang" Name="clang" />
+                <Directory Id="toolchains_asserts_usr_lib_swift" Name="swift">
+                  <Directory Id="toolchains_asserts_usr_lib_swift_clang" Name="clang" />
                 </Directory>
                 <Directory Id="_usr_lib_swift_static" Name="swift_static">
                   <Directory Id="_usr_lib_swift_static_clang" Name="clang" />
                 </Directory>
               </Directory>
-              <Directory Id="_usr_share" Name="share">
-                <Directory Id="_usr_share_docc" Name="docc">
-                  <Directory Id="_usr_share_docc_render" Name="render" />
+              <Directory Id="toolchains_asserts_usr_share" Name="share">
+                <Directory Id="toolchains_asserts_usr_share_docc" Name="docc">
+                  <Directory Id="toolchains_asserts_usr_share_docc_render" Name="render" />
                 </Directory>
               </Directory>
             </Directory>

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -38,7 +38,7 @@
   <Fragment>
     <DirectoryRef Id="INSTALLROOT">
         <Directory Name="Toolchains">
-          <Directory Id="ToolchainsVersioned" Name="$(ProductVersion)+Asserts">
+          <Directory Id="ToolchainsVersionedAsserts" Name="$(ProductVersion)+Asserts">
             <Directory Id="_usr" Name="usr">
               <Directory Id="_usr_bin" Name="bin" />
               <Directory Id="_usr_include" Name="include" />
@@ -86,8 +86,8 @@
       </Component>
 
       <Component Id="VersionedDirectoryCleanupToolchains">
-        <RegistryValue Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersioned" Value="[ToolchainsVersioned]" />
-        <util:RemoveFolderEx Property="TOOLCHAINSVERSIONED" Condition="TOOLCHAINSVERSIONED" />
+        <RegistryValue Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersionedAsserts" Value="[ToolchainsVersionedAsserts]" />
+        <util:RemoveFolderEx Property="TOOLCHAINSVERSIONEDASSERTS" Condition="TOOLCHAINSVERSIONEDASSERTS" />
       </Component>
     </ComponentGroup>
 
@@ -103,8 +103,8 @@
       <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="RuntimesVersioned" Type="directory" />
     </Property>
 
-    <Property Id="TOOLCHAINSVERSIONED">
-      <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersioned" Type="directory" />
+    <Property Id="TOOLCHAINSVERSIONEDASSERTS">
+      <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersionedAsserts" Type="directory" />
     </Property>
   </Fragment>
 

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -38,22 +38,22 @@
   <Fragment>
     <DirectoryRef Id="INSTALLROOT">
         <Directory Name="Toolchains">
-          <Directory Id="ToolchainsVersionedAsserts" Name="$(ProductVersion)+Asserts">
-            <Directory Id="toolchains_asserts_usr" Name="usr">
-              <Directory Id="toolchains_asserts_usr_bin" Name="bin" />
-              <Directory Id="toolchains_asserts_usr_include" Name="include" />
-              <Directory Id="toolchains_asserts_usr_lib" Name="lib">
-                <Directory Id="toolchains_asserts_usr_lib_clang" Name="clang" />
-                <Directory Id="toolchains_asserts_usr_lib_swift" Name="swift">
-                  <Directory Id="toolchains_asserts_usr_lib_swift_clang" Name="clang" />
+          <Directory Id="ToolchainVersionedAsserts" Name="$(ProductVersion)+Asserts">
+            <Directory Id="toolchain_asserts_usr" Name="usr">
+              <Directory Id="toolchain_asserts_usr_bin" Name="bin" />
+              <Directory Id="toolchain_asserts_usr_include" Name="include" />
+              <Directory Id="toolchain_asserts_usr_lib" Name="lib">
+                <Directory Id="toolchain_asserts_usr_lib_clang" Name="clang" />
+                <Directory Id="toolchain_asserts_usr_lib_swift" Name="swift">
+                  <Directory Id="toolchain_asserts_usr_lib_swift_clang" Name="clang" />
                 </Directory>
                 <Directory Id="_usr_lib_swift_static" Name="swift_static">
                   <Directory Id="_usr_lib_swift_static_clang" Name="clang" />
                 </Directory>
               </Directory>
-              <Directory Id="toolchains_asserts_usr_share" Name="share">
-                <Directory Id="toolchains_asserts_usr_share_docc" Name="docc">
-                  <Directory Id="toolchains_asserts_usr_share_docc_render" Name="render" />
+              <Directory Id="toolchain_asserts_usr_share" Name="share">
+                <Directory Id="toolchain_asserts_usr_share_docc" Name="docc">
+                  <Directory Id="toolchain_asserts_usr_share_docc_render" Name="render" />
                 </Directory>
               </Directory>
             </Directory>
@@ -86,8 +86,8 @@
       </Component>
 
       <Component Id="VersionedDirectoryCleanupToolchains">
-        <RegistryValue Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersionedAsserts" Value="[ToolchainsVersionedAsserts]" />
-        <util:RemoveFolderEx Property="TOOLCHAINSVERSIONEDASSERTS" Condition="TOOLCHAINSVERSIONEDASSERTS" />
+        <RegistryValue Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainVersionedAsserts" Value="[ToolchainVersionedAsserts]" />
+        <util:RemoveFolderEx Property="TOOLCHAINVERSIONEDASSERTS" Condition="TOOLCHAINVERSIONEDASSERTS" />
       </Component>
     </ComponentGroup>
 
@@ -103,8 +103,8 @@
       <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="RuntimesVersioned" Type="directory" />
     </Property>
 
-    <Property Id="TOOLCHAINSVERSIONEDASSERTS">
-      <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainsVersionedAsserts" Type="directory" />
+    <Property Id="TOOLCHAINVERSIONEDASSERTS">
+      <RegistrySearch Root="HKCU" Key="SOFTWARE\!(loc.ManufacturerName)\Installer\$(ProductVersion)\!(bind.Property.UpgradeCode)" Name="ToolchainVersionedAsserts" Type="directory" />
     </Property>
   </Fragment>
 


### PR DESCRIPTION
This is a follow up change to #428. In this PR we are making directory IDs reflect the variant in the name of the install directory (e.g. `Swift\Toolchains\6.2.0+Asserts\usr`). 

There is no functional change in this change, it is just directory ids. Directory names and which components are installed to which directories should not be changed. 

This should make it easier to add new variants by following the same pattern, and will allow us to parametrize authoring that is shared between variants.

Naming convention:
- `ToolchainsVersioned` became `ToolchainsVersionedAsserts` -- this is our top-level toolchain install directory like `Swift\Toolchains\0.0.0+Asserts`
- Subdirectories like `_usr_share` became `toolchains_asserts_usr_share` to reflect the full path at install time i.e.``Swift\Toolchains\0.0.0+Asserts\usr\share`