### PR TITLE
Reflect variant name in component group ids

### DIFF
--- a/platforms/Windows/bld/asserts/bld.asserts.wixproj
+++ b/platforms/Windows/bld/asserts/bld.asserts.wixproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\clang">
-      <ComponentGroupName>ClangResources</ComponentGroupName>
+      <ComponentGroupName>ClangResources_asserts</ComponentGroupName>
       <DirectoryRefId>_usr_lib_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <HarvestDirectory Include="$(ImageRoot)\Toolchains\$(ProductVersion)+Asserts\usr\lib\swift\clang">
-      <ComponentGroupName>SwiftClangResources</ComponentGroupName>
+      <ComponentGroupName>SwiftClangResources_asserts</ComponentGroupName>
       <DirectoryRefId>_usr_lib_swift_clang</DirectoryRefId>
       <PreprocessorVariable>var._USR_LIB_SWIFT_CLANG</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -571,8 +571,8 @@
       <ComponentGroupRef Id="TestingMacros" />
       <ComponentGroupRef Id="mimalloc" />
 
-      <ComponentGroupRef Id="ClangResources" />
-      <ComponentGroupRef Id="SwiftClangResources" />
+      <ComponentGroupRef Id="ClangResources_asserts" />
+      <ComponentGroupRef Id="SwiftClangResources_asserts" />
 
       <ComponentGroupRef Id="Configuration" />
       <ComponentGroupRef Id="EnvironmentVariables" />

--- a/platforms/Windows/cli/asserts/cli.asserts.wixproj
+++ b/platforms/Windows/cli/asserts/cli.asserts.wixproj
@@ -16,7 +16,7 @@
 
   <ItemGroup Condition=" '$(INCLUDE_SWIFT_DOCC)' == 'True' ">
     <HarvestDirectory Include="$(SWIFT_DOCC_RENDER_ARTIFACT_ROOT)\dist">
-      <ComponentGroupName>DocCRender</ComponentGroupName>
+      <ComponentGroupName>DocCRender_asserts</ComponentGroupName>
       <DirectoryRefId>_usr_share_docc_render</DirectoryRefId>
       <PreprocessorVariable>var.SWIFT_DOCC_RENDER_ARTIFACT_ROOT_DIST</PreprocessorVariable>
       <SuppressCom>true</SuppressCom>

--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -750,7 +750,7 @@
 
       <ComponentGroupRef Id="DocC" />
       <?if $(INCLUDE_SWIFT_DOCC) = True?>
-        <ComponentGroupRef Id="DocCRender" />
+        <ComponentGroupRef Id="DocCRender_asserts" />
       <?endif?>
 
       <ComponentGroupRef Id="swift_format" />


### PR DESCRIPTION
This is a follow up change to #428. In this PR we are making component group IDs reflect the variant in the name they are carrying. 

There is no functional change in this change, changes are only to component ids. 