### PR TITLE
WiX: Update FoundationCollections module names

### DIFF
--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -1474,48 +1474,30 @@
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_FoundationCollections.arm64" Directory="_FoundationCollections.swiftmodule">
         <Component DiskId="2">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
-          -->
-          <File Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\aarch64.swiftdoc" />
         </Component>
         <Component DiskId="2">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
-          -->
-          <File Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\aarch64.swiftmodule" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_FoundationCollections.x64" Directory="_FoundationCollections.swiftmodule">
         <Component DiskId="3">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
-          -->
-          <File Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\x86_64.swiftdoc" />
         </Component>
         <Component DiskId="3">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
-          -->
-          <File Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\x86_64.swiftmodule" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_FoundationCollections.x86" Directory="_FoundationCollections.swiftmodule">
         <Component DiskId="4">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
-          -->
-          <File Name="i686-unknown-windows-msvc.swiftdoc" Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\i686.swiftdoc" />
         </Component>
         <Component DiskId="4">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
-          -->
-          <File Name="i686-unknown-windows-msvc.swiftmodule" Source="$(SDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\i686.swiftmodule" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1523,16 +1505,10 @@
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="lib_FoundationCollections.arm64" Directory="lib_FoundationCollections.swiftmodule">
         <Component DiskId="6">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
-          -->
-          <File Name="aarch64-unknown-windows-msvc.swiftdoc" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64.swiftdoc" />
         </Component>
         <Component DiskId="6">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
-          -->
-          <File Name="aarch64-unknown-windows-msvc.swiftmodule" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64.swiftmodule" />
         </Component>
 
         <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
@@ -1543,16 +1519,10 @@
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="lib_FoundationCollections.x64" Directory="lib_FoundationCollections.swiftmodule">
         <Component DiskId="7">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
-          -->
-          <File Name="x86_64-unknown-windows-msvc.swiftdoc" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64.swiftdoc" />
         </Component>
         <Component DiskId="7">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
-          -->
-          <File Name="x86_64-unknown-windows-msvc.swiftmodule" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64.swiftmodule" />
         </Component>
 
         <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
@@ -1563,16 +1533,10 @@
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="lib_FoundationCollections.x86" Directory="lib_FoundationCollections.swiftmodule">
         <Component DiskId="8">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
-          -->
-          <File Name="i686-unknown-windows-msvc.swiftdoc" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686.swiftdoc" />
         </Component>
         <Component DiskId="8">
-          <!-- FIXME(swiftlang/swift-foundation#1230)
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
-          -->
-          <File Name="i686-unknown-windows-msvc.swiftmodule" Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686.swiftmodule" />
         </Component>
 
         <Component Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">


### PR DESCRIPTION
Swift-Collections [switched](https://github.com/apple/swift-collections/pull/470) to using the full module triple. We're updating Swift to use a newer Swift-Collections, so updating the filenames here.

Fixes: swiftlang/swift-foundation#1230