### PR TITLE
WiX: correct packaging for Android SDK on Windows

### DIFF
--- a/platforms/Windows/platforms/android/android.wxs
+++ b/platforms/Windows/platforms/android/android.wxs
@@ -452,7 +452,9 @@
 
     <!-- libdispatch -->
     <ComponentGroup Id="libdispatch" Directory="AndroidSDK_usr_include_dispatch">
+      <?define Disk = 1?>
       <?include ../CDispatch.wxi?>
+      <?undef Disk?>
 
       <Component Directory="AndroidSDK_usr_include_os">
         <File Source="$(SDKRoot)\usr\include\os\generic_base.h" />


### PR DESCRIPTION
We need to now specify the disk ID for dispatch components. We were missing one for the shared headers.