### PR TITLE
Fix broken env path setting in installer

### DIFF
--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -546,7 +546,7 @@
 
     <ComponentGroup Id="EnvironmentVariables">
       <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Directory="toolchain_asserts_usr_bin" Guid="ab52b870-23ee-42e8-9581-3fcbdfb9228c">
-        <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[_usr_bin]" />
+        <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[toolchain_asserts_usr_bin]" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
A change i missed in https://github.com/swiftlang/swift-installer-scripts/pull/432 causing us not to add the toolchain in the env path.
