### PR TITLE
WiX: package up the experimental dynamic SDK and the runtime redistributables

### DIFF
--- a/platforms/Windows/Directory.Build.props
+++ b/platforms/Windows/Directory.Build.props
@@ -84,6 +84,9 @@
       WindowsRuntimeARM64=$(WindowsRuntimeARM64);
       WindowsRuntimeX64=$(WindowsRuntimeX64);
       WindowsRuntimeX86=$(WindowsRuntimeX86);
+      WindowsExperimentalRuntimeARM64=$(WindowsExperimentalRuntimeARM64);
+      WindowsExperimentalRuntimeX64=$(WindowsExperimentalRuntimeX64);
+      WindowsExperimentalRuntimeX86=$(WindowsExperimentalRuntimeX86);
     </DefineConstants>
   </PropertyGroup>
 

--- a/platforms/Windows/Directory.Build.targets
+++ b/platforms/Windows/Directory.Build.targets
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'shared' AND '$(MSBuildProjectName)' != 'rtllib' AND '$(MSBuildProjectName)' != 'rtlmsm'">
+  <PropertyGroup>
+    <RuntimePackages>;rtllib;rtlmsm;rtl.static.msm;rtl.shared.lib;rtl.shared.msm;</RuntimePackages>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" ! $([System.String]::Copy('$(RuntimePackages)').Contains($(MSBuildProjectName))) ">
     <ProjectReference Include="$(MSBuildThisFileDirectory)shared\shared.wixproj" />
   </ItemGroup>
 

--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -26,6 +26,7 @@
     <IdeAssertsUpgradeCode>{8DD91C86-D13D-490B-B06B-9522A9CF504C}</IdeAssertsUpgradeCode>
     <IdeNoAssertsUpgradeCode>{C5519168-CF7B-4127-98B7-D886D9789B42}</IdeNoAssertsUpgradeCode>
     <RtlUpgradeCode>{BEA8C6DC-F73E-445B-9486-2333D1CF2886}</RtlUpgradeCode>
+    <ExperimentalRTLUpgradeCode>{F9BA01C7-0C7C-4898-90BD-9D6BB308F0B3}</ExperimentalRTLUpgradeCode>
     <AndroidPlatformUpgradeCode>{313B9C1F-D5B5-4FED-B7E0-138F1EE6B26A}</AndroidPlatformUpgradeCode>
     <WindowsPlatformUpgradeCode>{01AFF1CF-A025-41B6-BCBC-728D794353FD}</WindowsPlatformUpgradeCode>
   </PropertyGroup>
@@ -67,6 +68,7 @@
       IdeAssertsUpgradeCode=$(IdeAssertsUpgradeCode);
       IdeNoAssertsUpgradeCode=$(IdeNoAssertsUpgradeCode);
       RtlUpgradeCode=$(RtlUpgradeCode);
+      ExperimentalRTLUpgradeCode=$(ExperimentalRTLUpgradeCode);
       AndroidPlatformUpgradeCode=$(AndroidPlatformUpgradeCode);
       WindowsPlatformUpgradeCode=$(WindowsPlatformUpgradeCode);
     </DefineConstants>

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -34,6 +34,10 @@
     <ProjectReference Include="..\rtl\msi\rtlmsi.wixproj" BindName="rtl" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\rtl\shared\msi\rtl.shared.msi.wixproj" Properties="ProductArchitecture=$(ProductArchitecture)" BindName="rtl.shared" />
+  </ItemGroup>
+
   <ItemGroup Condition=" $(Platforms.Contains('android')) ">
     <ProjectReference Include="..\platforms\android\android.wixproj" Properties="AndroidArchitectures=$(AndroidArchitectures)" BindName="platform.android" />
   </ItemGroup>

--- a/platforms/Windows/platforms/windows/windows.wixproj
+++ b/platforms/Windows/platforms/windows/windows.wixproj
@@ -19,14 +19,20 @@
 
   <ItemGroup Condition=" $(WindowsArchitectures.Contains('i686')) ">
     <ProjectReference Include="..\..\rtl\msm\rtlmsm.wixproj" Properties="Platform=x86;ProductArchitecture=x86" BindName="rtl.x86.msm" />
+    <ProjectReference Include="..\..\rtl\shared\msm\rtl.shared.msm.wixproj" Properties="Platform=x86;ProductArchitecture=x86" BindName="rtl.shared.x86.msm" />
+    <ProjectReference Include="..\..\rtl\static\msm\rtl.static.msm.wixproj" Properties="Platform=x86;ProductArchitecture=x86" BindName="rtl.static.x86.msm" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(WindowsArchitectures.Contains('x86_64')) ">
     <ProjectReference Include="..\..\rtl\msm\rtlmsm.wixproj" Properties="Platform=x86;ProductArchitecture=amd64" BindName="rtl.amd64.msm" />
+    <ProjectReference Include="..\..\rtl\shared\msm\rtl.shared.msm.wixproj" Properties="Platform=x86;ProductArchitecture=amd64" BindName="rtl.shared.amd64.msm" />
+    <ProjectReference Include="..\..\rtl\static\msm\rtl.static.msm.wixproj" Properties="Platform=x86;ProductArchitecture=amd64" BindName="rtl.static.amd64.msm" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(WindowsArchitectures.Contains('aarch64')) ">
     <ProjectReference Include="..\..\rtl\msm\rtlmsm.wixproj" Properties="Platform=x86;ProductArchitecture=arm64" BindName="rtl.arm64.msm" />
+    <ProjectReference Include="..\..\rtl\shared\msm\rtl.shared.msm.wixproj" Properties="Platform=x86;ProductArchitecture=arm64" BindName="rtl.shared.arm64.msm" />
+    <ProjectReference Include="..\..\rtl\static\msm\rtl.static.msm.wixproj" Properties="Platform=x86;ProductArchitecture=arm64" BindName="rtl.static.arm64.msm" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -188,7 +188,7 @@
                 <Directory Name="lib">
                   <Directory Name="swift">
                     <Directory Id="WindowsExperimentalSDK_usr_lib_swift_apinotes" Name="apinotes" DiskId="5" />
-                    <Directory Id="WindowsExperimentalSDK_usr_lib_swift_shims" Name="shims" />
+                    <Directory Id="WindowsExperimentalSDK_usr_lib_swift_shims" Name="shims" DiskId="5" />
                     <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows" Name="windows">
                       <?if $(IncludeARM64) = True?>
                         <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows_arm64" Name="aarch64" DiskId="6" />

--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -190,6 +190,29 @@
                     <Directory Id="WindowsExperimentalSDK_usr_lib_swift_apinotes" Name="apinotes" DiskId="5" />
                     <Directory Id="WindowsExperimentalSDK_usr_lib_swift_shims" Name="shims" DiskId="5" />
                     <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows" Name="windows">
+                      <Directory Id="CRT.swiftmodule" Name="CRT.swiftmodule" />
+                      <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule" />
+                      <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
+                      <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule" />
+                      <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule" />
+                      <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
+                      <Directory Id="FoundationEssentials.swiftmodule" Name="FoundationEssentials.swiftmodule" />
+                      <Directory Id="FoundationInternationalization.swiftmodule" Name="FoundationInternationalization.swiftmodule" />
+                      <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
+                      <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="Observation.swiftmodule" Name="Observation.swiftmodule" />
+                      <Directory Id="RegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
+                      <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule" />
+                      <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
+                      <Directory Id="Synchronization.swiftmodule" Name="Synchronization.swiftmodule" />
+                      <Directory Id="WinSDK.swiftmodule" Name="WinSDK.swiftmodule" />
+                      <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule" />
+                      <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule" />
+                      <Directory Id="_FoundationCollections.swiftmodule" Name="_FoundationCollections.swiftmodule" />
+                      <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule" />
+                      <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule" />
+                      <Directory Id="_Volatile.swiftmodule" Name="_Volatile.swiftmodule" />
+                      <Directory Id="_Builtin_float.swiftmodule" Name="Builtin_float.swiftmodule" />
                       <?if $(IncludeARM64) = True?>
                         <Directory Id="WindowsExperimentalSDK_usr_lib_swift_windows_arm64" Name="aarch64" DiskId="6" />
                       <?endif?>
@@ -459,6 +482,11 @@
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="SwiftRemoteMirror.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftRemoteMirror.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwiftRemoteMirror.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\swiftRemoteMirror.lib" />
@@ -466,6 +494,11 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="SwiftRemoteMirror.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwiftRemoteMirror.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\swiftRemoteMirror.lib" />
@@ -473,6 +506,11 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="SwiftRemoteMirror.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftRemoteMirror.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwiftRemoteMirror.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\swiftRemoteMirror.lib" />
@@ -629,6 +667,11 @@
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="dispatch.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\dispatch.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libdispatch.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\dispatch.lib" />
@@ -636,6 +679,11 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="dispatch.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\dispatch.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libdispatch.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\dispatch.lib" />
@@ -643,6 +691,11 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="dispatch.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\dispatch.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libdispatch.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\dispatch.lib" />
@@ -651,6 +704,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="swiftDispatch.arm64" Directory="Dispatch.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64" DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftDispatch.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libswiftDispatch.arm64" Directory="libDispatch.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -665,6 +730,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="swiftDispatch.x64" Directory="Dispatch.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64" DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftDispatch.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libswiftDispatch.x64" Directory="libDispatch.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -679,6 +756,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="swiftDispatch.x86" Directory="Dispatch.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Dispatch.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86" DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftDispatch.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libswiftDispatch.x86" Directory="libDispatch.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Dispatch.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -729,6 +818,11 @@
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_FoundationUnicode.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\_FoundationICU.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_FoundationUnicode.arm64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_arm64">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\aarch64\_FoundationICU.lib" />
@@ -736,6 +830,11 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_FoundationUnicode.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\_FoundationICU.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_FoundationUnicode.x64" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x64">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\x86_64\_FoundationICU.lib" />
@@ -743,6 +842,11 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_FoundationUnicode.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\_FoundationICU.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_FoundationUnicode.x86" Directory="WindowsExperimentalSDK_usr_lib_swift_static_windows_x86">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\i686\_FoundationICU.lib" />
@@ -839,6 +943,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_Builtin_float.arm64" Directory="_Builtin_float.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Builtin_float.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Builtin_float.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swift_Builtin_float.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Builtin_float.arm64" Directory="lib_Builtin_float.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -853,6 +969,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_Builtin_float.x64" Directory="_Builtin_float.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Builtin_float.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Builtin_float.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swift_Builtin_float.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Builtin_float.x64" Directory="lib_Builtin_float.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -867,6 +995,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_Builtin_float.x86" Directory="_Builtin_float.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Builtin_float.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Builtin_float.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swift_Builtin_float.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Builtin_float.x86" Directory="lib_Builtin_float.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Builtin_float.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -935,6 +1075,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_Concurrency.arm64" Directory="_Concurrency.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swift_Concurrency.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Concurrency.arm64" Directory="lib_Concurrency.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -949,6 +1101,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_Concurrency.x64" Directory="_Concurrency.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swift_Concurrency.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Concurrency.x64" Directory="lib_Concurrency.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -963,6 +1127,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_Concurrency.x86" Directory="_Concurrency.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swift_Concurrency.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Concurrency.x86" Directory="lib_Concurrency.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Concurrency.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1031,6 +1207,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_Differentiation.arm64" Directory="_Differentiation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Differentiation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Differentiation.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swift_Differentiation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Differentiation.arm64" Directory="lib_Differentiation.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Differentiation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1045,6 +1233,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_Differentiation.x64" Directory="_Differentiation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swift_Differentiation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Differentiation.x64" Directory="lib_Differentiation.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Differentiation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1059,6 +1259,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_Differentiation.x86" Directory="_Differentiation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swift_Differentiation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Differentiation.x86" Directory="lib_Differentiation.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Differentiation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1118,6 +1330,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_RegexParser.arm64" Directory="_RegexParser.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swift_RegexParser.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_RegexParser.arm64" Directory="lib_RegexParser.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1132,6 +1356,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_RegexParser.x64" Directory="_RegexParser.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swift_RegexParser.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_RegexParser.x64" Directory="lib_RegexParser.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1146,6 +1382,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_RegexParser.x86" Directory="_RegexParser.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swift_RegexParser.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_RegexParser.x86" Directory="lib_RegexParser.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_RegexParser.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1214,6 +1462,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_StringProcessing.arm64" Directory="_StringProcessing.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swift_StringProcessing.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_StringProcessing.arm64" Directory="lib_StringProcessing.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1228,6 +1488,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_StringProcessing.x64" Directory="_StringProcessing.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swift_StringProcessing.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_StringProcessing.x64" Directory="lib_StringProcessing.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1242,6 +1514,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_StringProcessing.x86" Directory="_StringProcessing.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swift_StringProcessing.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_StringProcessing.x86" Directory="lib_StringProcessing.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_StringProcessing.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1310,6 +1594,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_Volatile.arm64" Directory="_Volatile.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Volatile.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Volatile.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swift_Volatile.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Volatile.arm64" Directory="lib_Volatile.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Volatile.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1324,6 +1620,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_Volatile.x64" Directory="_Volatile.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Volatile.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Volatile.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swift_Volatile.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Volatile.x64" Directory="lib_Volatile.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Volatile.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1338,6 +1646,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_Volatile.x86" Directory="_Volatile.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Volatile.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_Volatile.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swift_Volatile.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_Volatile.x86" Directory="lib_Volatile.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_Volatile.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1406,6 +1726,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="CRT.arm64" Directory="CRT.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftCRT.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCRT.arm64" Directory="libCRT.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1420,6 +1752,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="CRT.x64" Directory="CRT.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftCRT.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCRT.x64" Directory="libCRT.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1434,6 +1778,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="CRT.x86" Directory="CRT.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftCRT.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCRT.x86" Directory="libCRT.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CRT.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1502,6 +1858,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="Cxx.arm64" Directory="Cxx.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\libswiftCxx.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCxx.arm64" Directory="libCxx.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Cxx.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1516,6 +1884,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="Cxx.x64" Directory="Cxx.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\libswiftCxx.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCxx.x64" Directory="libCxx.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Cxx.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1530,6 +1910,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="Cxx.x86" Directory="Cxx.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\libswiftCxx.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCxx.x86" Directory="libCxx.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Cxx.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1598,6 +1990,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="CxxStdlib.arm64" Directory="CxxStdlib.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\libswiftCxxStdlib.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCxxStdlib.arm64" Directory="libCxxStdlib.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1612,6 +2016,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="CxxStdlib.x64" Directory="CxxStdlib.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\libswiftCxxStdlib.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCxxStdlib.x64" Directory="libCxxStdlib.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1626,6 +2042,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="CxxStdlib.x86" Directory="CxxStdlib.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\libswiftCxxStdlib.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libCxxStdlib.x86" Directory="libCxxStdlib.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\CxxStdlib.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1694,6 +2122,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="Distributed.arm64" Directory="Distributed.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Distributed.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Distributed.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftDistributed.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libDistributed.arm64" Directory="libDistributed.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Distributed.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1708,6 +2148,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="Distributed.x64" Directory="Distributed.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftDistributed.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libDistributed.x64" Directory="libDistributed.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Distributed.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1722,6 +2174,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="Distributed.x86" Directory="Distributed.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftDistributed.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libDistributed.x86" Directory="libDistributed.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Distributed.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1769,6 +2233,14 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="_FoundationCollections.arm64" Directory="_FoundationCollections.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_FoundationCollections.arm64" Directory="lib_FoundationCollections.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1783,6 +2255,14 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="_FoundationCollections.x64" Directory="_FoundationCollections.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_FoundationCollections.x64" Directory="lib_FoundationCollections.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1797,6 +2277,14 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="_FoundationCollections.x86" Directory="_FoundationCollections.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="lib_FoundationCollections.x86" Directory="lib_FoundationCollections.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\_FoundationCollections.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1856,6 +2344,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="FoundationEssentials.arm64" Directory="FoundationEssentials.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationEssentials.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationEssentials.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\FoundationEssentials.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationEssentials.arm64" Directory="libFoundationEssentials.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1870,6 +2370,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="FoundationEssentials.x64" Directory="FoundationEssentials.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationEssentials.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationEssentials.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\FoundationEssentials.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationEssentials.x64" Directory="libFoundationEssentials.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1884,6 +2396,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="FoundationEssentials.x86" Directory="FoundationEssentials.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationEssentials.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationEssentials.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\FoundationEssentials.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationEssentials.x86" Directory="libFoundationEssentials.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationEssentials.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -1943,6 +2467,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="FoundationInternationalization.arm64" Directory="FoundationInternationalization.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationInternationalization.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationInternationalization.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\FoundationInternationalization.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationInternationalization.arm64" Directory="libFoundationInternationalization.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -1957,6 +2493,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="FoundationInternationalization.x64" Directory="FoundationInternationalization.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationInternationalization.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationInternationalization.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\FoundationInternationalization.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationInternationalization.x64" Directory="libFoundationInternationalization.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -1971,6 +2519,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="FoundationInternationalization.x86" Directory="FoundationInternationalization.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationInternationalization.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationInternationalization.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\FoundationInternationalization.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationInternationalization.x86" Directory="libFoundationInternationalization.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationInternationalization.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2029,6 +2589,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="Foundation.arm64" Directory="Foundation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Foundation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Foundation.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\Foundation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundation.arm64" Directory="libFoundation.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2043,6 +2615,17 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="Foundation.x64" Directory="Foundation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Foundation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Foundation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\Foundation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundation.x64" Directory="libFoundation.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2056,6 +2639,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="Foundation.x86" Directory="Foundation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Foundation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Foundation.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\Foundation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundation.x86" Directory="libFoundation.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Foundation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2115,6 +2710,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="FoundationNetworking.arm64" Directory="FoundationNetworking.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationNetworking.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationNetworking.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\FoundationNetworking.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationNetworking.arm64" Directory="libFoundationNetworking.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2129,6 +2736,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="FoundationNetworking.x64" Directory="FoundationNetworking.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationNetworking.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationNetworking.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\FoundationNetworking.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationNetworking.x64" Directory="libFoundationNetworking.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2143,6 +2762,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="FoundationNetworking.x86" Directory="FoundationNetworking.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationNetworking.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationNetworking.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\FoundationNetworking.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationNetworking.x86" Directory="libFoundationNetworking.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationNetworking.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2202,6 +2833,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="FoundationXML.arm64" Directory="FoundationXML.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationXML.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationXML.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\FoundationXML.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationXML.arm64" Directory="libFoundationXML.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2216,6 +2859,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="FoundationXML.x64" Directory="FoundationXML.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationXML.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationXML.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\FoundationXML.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationXML.x64" Directory="libFoundationXML.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2230,6 +2885,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="FoundationXML.x86" Directory="FoundationXML.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationXML.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\FoundationXML.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\FoundationXML.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libFoundationXML.x86" Directory="libFoundationXML.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\FoundationXML.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2298,6 +2965,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="Observation.arm64" Directory="Observation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Observation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Observation.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftObservation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libObservation.arm64" Directory="libObservation.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Observation.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2312,6 +2991,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="Observation.x64" Directory="Observation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Observation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Observation.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftObservation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libObservation.x64" Directory="libObservation.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Observation.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2326,6 +3017,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="Observation.x86" Directory="Observation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Observation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Observation.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftObservation.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libObservation.x86" Directory="libObservation.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Observation.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2394,6 +3097,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="RegexBuilder.arm64" Directory="RegexBuilder.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\RegexBuilder.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\RegexBuilder.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftRegexBuilder.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libRegexBuilder.arm64" Directory="libRegexBuilder.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2408,6 +3123,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="RegexBuilder.x64" Directory="RegexBuilder.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\RegexBuilder.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\RegexBuilder.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftRegexBuilder.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libRegexBuilder.x64" Directory="libRegexBuilder.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2422,6 +3149,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="RegexBuilder.x86" Directory="RegexBuilder.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\RegexBuilder.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\RegexBuilder.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftRegexBuilder.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libRegexBuilder.x86" Directory="libRegexBuilder.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\RegexBuilder.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2487,6 +3226,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="Swift.arm64" Directory="Swift.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftCore.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwift.arm64" Directory="libSwift.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2501,6 +3252,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="Swift.x64" Directory="Swift.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftCore.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwift.x64" Directory="libSwift.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2515,6 +3278,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="Swift.x86" Directory="Swift.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftCore.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwift.x86" Directory="libSwift.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Swift.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2583,6 +3358,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="SwiftOnoneSupport.arm64" Directory="SwiftOnoneSupport.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftSwiftOnoneSupport.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwiftOnoneSupport.arm64" Directory="libSwiftOnoneSupport.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2597,6 +3384,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="SwiftOnoneSupport.x64" Directory="SwiftOnoneSupport.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftSwiftOnoneSupport.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwiftOnoneSupport.x64" Directory="libSwiftOnoneSupport.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2611,6 +3410,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="SwiftOnoneSupport.x86" Directory="SwiftOnoneSupport.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftSwiftOnoneSupport.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSwiftOnoneSupport.x86" Directory="libSwiftOnoneSupport.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\SwiftOnoneSupport.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2679,6 +3490,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="Synchronization.arm64" Directory="Synchronization.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Synchronization.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Synchronization.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64" DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftSynchronization.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSynchronization.arm64" Directory="libSynchronization.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2693,6 +3516,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="Synchronization.x64" Directory="Synchronization.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Synchronization.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Synchronization.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64" DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftSynchronization.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSynchronization.x64" Directory="libSynchronization.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2707,6 +3542,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="Synchronization.x86" Directory="Synchronization.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Synchronization.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\Synchronization.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86" DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftSynchronization.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libSynchronization.x86" Directory="libSynchronization.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\Synchronization.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -2775,6 +3622,18 @@
     <?endif?>
 
     <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="WinSDK.arm64" Directory="WinSDK.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_arm64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\aarch64\swiftWinSDK.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libWinSDK.arm64" Directory="libWinSDK.swiftmodule">
         <Component DiskId="6">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\aarch64-unknown-windows-msvc.swiftdoc" />
@@ -2789,6 +3648,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="WinSDK.x64" Directory="WinSDK.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x64">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\x86_64\swiftWinSDK.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libWinSDK.x64" Directory="libWinSDK.swiftmodule">
         <Component DiskId="7">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\x86_64-unknown-windows-msvc.swiftdoc" />
@@ -2803,6 +3674,18 @@
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="WinSDK.x86" Directory="WinSDK.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftmodule" />
+        </Component>
+
+        <Component Directory="WindowsExperimentalSDK_usr_lib_swift_windows_x86">
+          <File Source="$(ExperimentalSDKRoot)\usr\lib\swift\windows\i686\swiftWinSDK.lib" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libWinSDK.x86" Directory="libWinSDK.swiftmodule">
         <Component DiskId="8">
           <File Source="$(ExperimentalSDKRoot)\usr\lib\swift_static\windows\WinSDK.swiftmodule\i686-unknown-windows-msvc.swiftdoc" />
@@ -3223,6 +4106,33 @@
       <Feature Id="ExperimentalARM64" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_arm64)">
         <Level Condition="InstallARM64ExperimentalSDK = 1" Value="1" />
 
+        <ComponentGroupRef Id="CRT.arm64" />
+        <ComponentGroupRef Id="Cxx.arm64" />
+        <ComponentGroupRef Id="CxxStdlib.arm64" />
+        <ComponentGroupRef Id="Distributed.arm64" />
+        <ComponentGroupRef Id="Foundation.arm64" />
+        <ComponentGroupRef Id="FoundationEssentials.arm64" />
+        <ComponentGroupRef Id="FoundationInternationalization.arm64" />
+        <ComponentGroupRef Id="FoundationNetworking.arm64" />
+        <ComponentGroupRef Id="FoundationXML.arm64" />
+        <ComponentGroupRef Id="Observation.arm64" />
+        <ComponentGroupRef Id="RegexBuilder.arm64" />
+        <ComponentGroupRef Id="Swift.arm64" />
+        <ComponentGroupRef Id="SwiftOnoneSupport.arm64" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.arm64" />
+        <ComponentGroupRef Id="Synchronization.arm64" />
+        <ComponentGroupRef Id="WinSDK.arm64" />
+        <ComponentGroupRef Id="_Builtin_float.arm64" />
+        <ComponentGroupRef Id="_Concurrency.arm64" />
+        <ComponentGroupRef Id="_Differentiation.arm64" />
+        <ComponentGroupRef Id="_FoundationCollections.arm64" />
+        <ComponentGroupRef Id="_FoundationUnicode.arm64" />
+        <ComponentGroupRef Id="_RegexParser.arm64" />
+        <ComponentGroupRef Id="_StringProcessing.arm64" />
+        <ComponentGroupRef Id="_Volatile.arm64" />
+        <ComponentGroupRef Id="dispatch.arm64" />
+        <ComponentGroupRef Id="swiftDispatch.arm64" />
+
         <ComponentGroupRef Id="CoreFoundation.arm64" />
         <ComponentGroupRef Id="libBlocksRuntime.arm64" />
         <ComponentGroupRef Id="libCRT.arm64" />
@@ -3261,6 +4171,33 @@
       <Feature Id="ExperimentalX64" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_amd64)">
         <Level Condition="InstallX64ExperimentalSDK = 1" Value="1" />
 
+        <ComponentGroupRef Id="CRT.x64" />
+        <ComponentGroupRef Id="Cxx.x64" />
+        <ComponentGroupRef Id="CxxStdlib.x64" />
+        <ComponentGroupRef Id="Distributed.x64" />
+        <ComponentGroupRef Id="Foundation.x64" />
+        <ComponentGroupRef Id="FoundationEssentials.x64" />
+        <ComponentGroupRef Id="FoundationInternationalization.x64" />
+        <ComponentGroupRef Id="FoundationNetworking.x64" />
+        <ComponentGroupRef Id="FoundationXML.x64" />
+        <ComponentGroupRef Id="Observation.x64" />
+        <ComponentGroupRef Id="RegexBuilder.x64" />
+        <ComponentGroupRef Id="Swift.x64" />
+        <ComponentGroupRef Id="SwiftOnoneSupport.x64" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.x64" />
+        <ComponentGroupRef Id="Synchronization.x64" />
+        <ComponentGroupRef Id="WinSDK.x64" />
+        <ComponentGroupRef Id="_Builtin_float.x64" />
+        <ComponentGroupRef Id="_Concurrency.x64" />
+        <ComponentGroupRef Id="_Differentiation.x64" />
+        <ComponentGroupRef Id="_FoundationCollections.x64" />
+        <ComponentGroupRef Id="_FoundationUnicode.x64" />
+        <ComponentGroupRef Id="_RegexParser.x64" />
+        <ComponentGroupRef Id="_StringProcessing.x64" />
+        <ComponentGroupRef Id="_Volatile.x64" />
+        <ComponentGroupRef Id="dispatch.x64" />
+        <ComponentGroupRef Id="swiftDispatch.x64" />
+
         <ComponentGroupRef Id="CoreFoundation.x64" />
         <ComponentGroupRef Id="libBlocksRuntime.x64" />
         <ComponentGroupRef Id="libCRT.x64" />
@@ -3298,6 +4235,33 @@
     <?if $(IncludeX86) = True?>
       <Feature Id="ExperimentalX86" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_x86)">
         <Level Condition="InstallX86ExperimentalSDK = 1" Value="1" />
+
+        <ComponentGroupRef Id="CRT.x86" />
+        <ComponentGroupRef Id="Cxx.x86" />
+        <ComponentGroupRef Id="CxxStdlib.x86" />
+        <ComponentGroupRef Id="Distributed.x86" />
+        <ComponentGroupRef Id="Foundation.x86" />
+        <ComponentGroupRef Id="FoundationEssentials.x86" />
+        <ComponentGroupRef Id="FoundationInternationalization.x86" />
+        <ComponentGroupRef Id="FoundationNetworking.x86" />
+        <ComponentGroupRef Id="FoundationXML.x86" />
+        <ComponentGroupRef Id="Observation.x86" />
+        <ComponentGroupRef Id="RegexBuilder.x86" />
+        <ComponentGroupRef Id="Swift.x86" />
+        <ComponentGroupRef Id="SwiftOnoneSupport.x86" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.x86" />
+        <ComponentGroupRef Id="Synchronization.x86" />
+        <ComponentGroupRef Id="WinSDK.x86" />
+        <ComponentGroupRef Id="_Builtin_float.x86" />
+        <ComponentGroupRef Id="_Concurrency.x86" />
+        <ComponentGroupRef Id="_Differentiation.x86" />
+        <ComponentGroupRef Id="_FoundationCollections.x86" />
+        <ComponentGroupRef Id="_FoundationUnicode.x86" />
+        <ComponentGroupRef Id="_RegexParser.x86" />
+        <ComponentGroupRef Id="_StringProcessing.x86" />
+        <ComponentGroupRef Id="_Volatile.x86" />
+        <ComponentGroupRef Id="dispatch.x86" />
+        <ComponentGroupRef Id="swiftDispatch.x86" />
 
         <ComponentGroupRef Id="CoreFoundation.x86" />
         <ComponentGroupRef Id="libBlocksRuntime.x86" />

--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -3874,15 +3874,33 @@
       <Component Id="rtl.arm64.msm" Directory="RedistVersion" Condition="INSTALLARM64REDIST" DiskId="2">
         <File Source="!(bindpath.rtl.arm64.msm)\rtl.arm64.msm" />
       </Component>
+      <Component Id="rtl.shared.arm64.msm" Directory="RedistVersion" Condition="INSTALLARM64REDIST" DiskId="6">
+        <File Source="!(bindpath.rtl.shared.arm64.msm)\rtl.shared.arm64.msm" />
+      </Component>
+      <Component Id="rtl.static.arm64.msm" Directory="RedistVersion" Condition="INSTALLARM64REDIST" DiskId="6">
+        <File Source="!(bindpath.rtl.static.arm64.msm)\rtl.static.arm64.msm" />
+      </Component>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <Component Id="rtl.amd64.msm" Directory="RedistVersion" Condition="INSTALLAMD64REDIST" DiskId="3">
         <File Source="!(bindpath.rtl.amd64.msm)\rtl.amd64.msm" />
       </Component>
+      <Component Id="rtl.shared.amd64.msm" Directory="RedistVersion" Condition="INSTALLAMD64REDIST" DiskId="7">
+        <File Source="!(bindpath.rtl.shared.amd64.msm)\rtl.shared.amd64.msm" />
+      </Component>
+      <Component Id="rtl.static.amd64.msm" Directory="RedistVersion" Condition="INSTALLAMD64REDIST" DiskId="7">
+        <File Source="!(bindpath.rtl.static.amd64.msm)\rtl.static.amd64.msm" />
+      </Component>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <Component Id="rtl.x86.msm" Directory="RedistVersion" Condition="INSTALLX86REDIST" DiskId="4">
         <File Source="!(bindpath.rtl.x86.msm)\rtl.x86.msm" />
+      </Component>
+      <Component Id="rtl.shared.x86.msm" Directory="RedistVersion" Condition="INSTALLX86REDIST" DiskId="8">
+        <File Source="!(bindpath.rtl.shared.x86.msm)\rtl.shared.x86.msm" />
+      </Component>
+      <Component Id="rtl.static.x86.msm" Directory="RedistVersion" Condition="INSTALLX86REDIST" DiskId="8">
+        <File Source="!(bindpath.rtl.static.x86.msm)\rtl.static.x86.msm" />
       </Component>
     <?endif?>
 
@@ -4164,6 +4182,10 @@
         <ComponentGroupRef Id="libswiftDispatch.arm64" />
 
         <ComponentGroupRef Id="ExperimentalRegistrar.arm64" />
+
+        <!-- Redistributable -->
+        <ComponentRef Id="rtl.shared.arm64.msm" />
+        <ComponentRef Id="rtl.static.arm64.msm" />
       </Feature>
     <?endif?>
 
@@ -4229,6 +4251,10 @@
         <ComponentGroupRef Id="libswiftDispatch.x64" />
 
         <ComponentGroupRef Id="ExperimentalRegistrar.x64" />
+
+        <!-- Redistributable -->
+        <ComponentRef Id="rtl.shared.amd64.msm" />
+        <ComponentRef Id="rtl.static.amd64.msm" />
       </Feature>
     <?endif?>
 
@@ -4294,6 +4320,10 @@
         <ComponentGroupRef Id="libswiftDispatch.x86" />
 
         <ComponentGroupRef Id="ExperimentalRegistrar.x86" />
+
+        <!-- Redistributable -->
+        <ComponentRef Id="rtl.shared.x86.msm" />
+        <ComponentRef Id="rtl.static.x86.msm" />
       </Feature>
     <?endif?>
   </Package>

--- a/platforms/Windows/rtl/shared/lib/rtl.shared.lib.wixproj
+++ b/platforms/Windows/rtl/shared/lib/rtl.shared.lib.wixproj
@@ -1,0 +1,7 @@
+<Project Sdk="WixToolset.Sdk/4.0.5">
+  <PropertyGroup>
+    <OutputName>rtl.shared.$(ProductArchitecture)</OutputName>
+    <OutputType>Library</OutputType>
+    <BindFiles>true</BindFiles>
+  </PropertyGroup>
+</Project>

--- a/platforms/Windows/rtl/shared/lib/rtl.shared.lib.wxs
+++ b/platforms/Windows/rtl/shared/lib/rtl.shared.lib.wxs
@@ -1,0 +1,123 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <?if $(sys.BUILDARCH) == x64 ?>
+      <?define RuntimeDirectoryComponentGuidGenerationSeed = "E33B165B-8460-467D-ABCD-27EA8197A3CF" ?>
+      <?define RuntimeRoot = $(WindowsExperimentalRuntimeX64)?>
+    <?elseif $(sys.BUILDARCH) == arm64 ?>
+      <?define RuntimeDirectoryComponentGuidGenerationSeed = "BFFDD8F7-CC47-40CB-AF0E-095273FF10FC" ?>
+      <?define RuntimeRoot = $(WindowsExperimentalRuntimeARM64)?>
+    <?elseif $(sys.BUILDARCH) == x86 ?>
+      <?define RuntimeDirectoryComponentGuidGenerationSeed = "72064820-3795-4331-8CBD-FF1ABA7DAE7B" ?>
+      <?define RuntimeRoot = $(WindowsExperimentalRuntimeX86)?>
+    <?endif?>
+
+    <Directory Id="RUNTIMEDIR_$(ProductArchitecture)" ComponentGuidGenerationSeed="$(RuntimeDirectoryComponentGuidGenerationSeed)" />
+
+    <ComponentGroup Id="stdlib_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftCore.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftCRT.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftDistributed.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftObservation.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftRegexBuilder.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftRemoteMirror.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftSwiftOnoneSupport.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftSynchronization.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftWinSDK.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swift_Builtin_float.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swift_Concurrency.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swift_Differentiation.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swift_RegexParser.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swift_StringProcessing.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swift_Volatile.dll" />
+      </Component>
+
+      <!-- TODO(compnerd) should we distribute the undecoration library in the runtime?
+      <Component Directory="_usr_bin" Id="swiftDemangle.dll">
+        <File Id="swiftDemangle.dll" Source="$(RuntimeRoot)\bin\swiftDemangle.dll" />
+      </Component>
+      -->
+    </ComponentGroup>
+
+    <ComponentGroup Id="BlocksRuntime_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\BlocksRuntime.dll" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="libdispatch_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\dispatch.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\swiftDispatch.dll" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Foundation_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\Foundation.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\FoundationEssentials.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\FoundationInternationalization.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\FoundationNetworking.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\FoundationXML.dll" />
+      </Component>
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\_FoundationICU.dll" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="plutil_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component>
+        <File Source="$(RuntimeRoot)\usr\bin\plutil.exe" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="swift_runtime_$(ProductArchitecture)">
+      <ComponentGroupRef Id="stdlib_$(ProductArchitecture)" />
+      <ComponentGroupRef Id="BlocksRuntime_$(ProductArchitecture)" />
+      <ComponentGroupRef Id="libdispatch_$(ProductArchitecture)" />
+      <ComponentGroupRef Id="Foundation_$(ProductArchitecture)" />
+    </ComponentGroup>
+
+    <ComponentGroup Id="swift_runtime_utilities_$(ProductArchitecture)">
+      <ComponentGroupRef Id="plutil_$(ProductArchitecture)" />
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/platforms/Windows/rtl/shared/msi/rtl.shared.msi.wixproj
+++ b/platforms/Windows/rtl/shared/msi/rtl.shared.msi.wixproj
@@ -1,0 +1,36 @@
+<Project Sdk="WixToolset.Sdk/4.0.5">
+  <PropertyGroup>
+    <OutputName>rtl.$(ProductArchitecture)</OutputName>
+    <DefineConstants>
+      $(DefineConstants);
+      VCRedistDir=$(VCRedistDir);
+    </DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
+    <ProjectReference Include="..\lib\rtl.shared.lib.wixproj" Properties="ProductArchitecture=amd64;Platform=x64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
+    <ProjectReference Include="..\lib\rtl.shared.lib.wixproj" Properties="ProductArchitecture=arm64;Platform=arm64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
+    <ProjectReference Include="..\lib\rtl.shared.lib.wixproj" Properties="ProductArchitecture=x86;Platform=x86" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Heat" Version="4.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <HarvestDirectory Include="$(VCRedistDir)">
+      <ComponentGroupName>VCRuntime_$(ProductArchitecture)</ComponentGroupName>
+      <DirectoryRefId>RUNTIMEDIR_$(ProductArchitecture)</DirectoryRefId>
+      <PreprocessorVariable>var.VCRedistDir</PreprocessorVariable>
+      <SuppressCom>true</SuppressCom>
+      <SuppressRegistry>true</SuppressRegistry>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+    </HarvestDirectory>
+  </ItemGroup>
+</Project>

--- a/platforms/Windows/rtl/shared/msi/rtl.shared.msi.wxs
+++ b/platforms/Windows/rtl/shared/msi/rtl.shared.msi.wxs
@@ -1,0 +1,40 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+      Language="1033"
+      Manufacturer="!(loc.ManufacturerName)"
+      Name="!(loc.Rtl_ProductName_$(ProductArchitecture))"
+      UpgradeCode="$(ExperimentalRTLUpgradeCode)"
+      Version="$(NonSemVerProductVersion)"
+      Scope="$(PackageScope)">
+
+    <Media Id="1" Cabinet="rtl.$(ProductArchitecture).cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+
+    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(ExperimentalRTLUpgradeCode)" />
+    <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
+
+    <!-- Point the RTL component group to the right directory. -->
+    <DirectoryRef Id="runtimes_usr_bin" />
+    <SetDirectory Id="RUNTIMEDIR_$(ProductArchitecture)" Value="[runtimes_usr_bin]" Sequence="first" />
+
+    <ComponentGroup Id="EnvironmentVariables" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component Id="UserPathVariable" Condition="NOT ALLUSERS=1" Guid="bc309c80-221e-48db-b989-07157ac8f286">
+        <Environment Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[runtimes_usr_bin]" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="VCRuntime" AllowAbsent="no" Title="!(loc.VCRuntime_ProductName_$(ProductArchitecture))">
+      <ComponentGroupRef Id="VCRuntime_$(ProductArchitecture)" />
+    </Feature>
+
+    <Feature Id="SwiftRuntime" AllowAbsent="no" Title="!(loc.Rtl_ProductName_$(ProductArchitecture))">
+      <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />
+      <ComponentGroupRef Id="EnvironmentVariables" />
+      <ComponentGroupRef Id="VersionedDirectoryCleanup" />
+    </Feature>
+
+    <Feature Id="SwiftRuntimeUtilities" AllowAbsent="yes" Title="!(loc.Utl_ProductName_$(ProductArchitecture))">
+      <Level Condition="INSTALLUTILITIES = 0" Value="0" />
+      <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />
+    </Feature>
+  </Package>
+</Wix>

--- a/platforms/Windows/rtl/shared/msm/rtl.shared.msm.wixproj
+++ b/platforms/Windows/rtl/shared/msm/rtl.shared.msm.wixproj
@@ -1,0 +1,18 @@
+<Project Sdk="WixToolset.Sdk/4.0.5">
+  <PropertyGroup>
+    <OutputType>Module</OutputType>
+    <OutputName>rtl.shared.$(ProductArchitecture)</OutputName>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
+    <ProjectReference Include="..\lib\rtl.shared.lib.wixproj" Properties="ProductArchitecture=amd64;Platform=x64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
+    <ProjectReference Include="..\lib\rtl.shared.lib.wixproj" Properties="ProductArchitecture=arm64;Platform=arm64" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
+    <ProjectReference Include="..\lib\rtl.shared.lib.wixproj" Properties="ProductArchitecture=x86;Platform=x86" />
+  </ItemGroup>
+</Project>

--- a/platforms/Windows/rtl/shared/msm/rtl.shared.msm.wxs
+++ b/platforms/Windows/rtl/shared/msm/rtl.shared.msm.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <?if $(sys.BUILDARCH) == x64 ?>
+    <?define ModuleId = "18546442-4BD6-4B39-B030-7B4F46CF07F8" ?>
+  <?elseif $(sys.BUILDARCH) == arm64 ?>
+    <?define ModuleId = "41013040-0B93-4BA0-8544-9437366AD3CF" ?>
+  <?elseif $(sys.BUILDARCH) == x86 ?>
+    <?define ModuleId = "B4250F08-F3A0-4A7A-A27D-24CC473D5F16" ?>
+  <?endif?>
+
+  <Module Guid="$(ModuleId)" Id="swift_runtime" Language="0" Version="$(NonSemVerProductVersion)">
+    <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />
+    <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />
+  </Module>
+</Wix>

--- a/platforms/Windows/rtl/static/msm/rtl.static.msm.wixproj
+++ b/platforms/Windows/rtl/static/msm/rtl.static.msm.wixproj
@@ -1,0 +1,6 @@
+<Project Sdk="WixToolset.Sdk/4.0.5">
+  <PropertyGroup>
+    <OutputType>Module</OutputType>
+    <OutputName>rtl.static.$(ProductArchitecture)</OutputName>
+  </PropertyGroup>
+</Project>

--- a/platforms/Windows/rtl/static/msm/rtl.static.msm.wxs
+++ b/platforms/Windows/rtl/static/msm/rtl.static.msm.wxs
@@ -1,0 +1,28 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <?if $(sys.BUILDARCH) == x86 ?>
+    <?define RuntimeDirectoryComponentGuidGenerationSeed = "D3021274-DCA3-4369-82D3-B6CEE436A3FC" ?>
+    <?define ModuleID = "53C54287-A59A-4828-A526-4F64E00B340E" ?>
+    <?define RuntimeRoot = $(WindowsExperimentalRuntimeX64)?>
+  <?elseif $(sys.BUILDARCH) == x64 ?>
+    <?define RuntimeDirectoryComponentGuidGenerationSeed = "639A8564-3505-4424-BA2F-449AAF743A90" ?>
+    <?define ModuleID = "F84DDCA4-72B0-42AB-9316-21DBAB241540" ?>
+    <?define RuntimeRoot = $(WindowsExperimentalRuntimeARM64)?>
+  <?elseif $(sys.BUILDARCH) == arm64 ?>
+    <?define RuntimeDirectoryComponentGuidGenerationSeed = "F8BF026F-8E3F-42B5-A5E7-E0A4D186EDF3" ?>
+    <?define ModuleID = "0439EF46-C6C2-43DF-A5A7-8F4C3F5C64A7" ?>
+    <?define RuntimeRoot = $(WindowsExperimentalRuntimeX86)?>
+  <?endif?>
+
+  <Module Guid="$(ModuleID)" Id="swift_runtime" Language="0" Version="$(NonSemVerProductVersion)">
+    <Directory Id="RUNTIMEDIR_$(ProductArchitecture)" ComponentGuidGenerationSeed="$(RuntimeDirectoryComponentGuidGenerationSeed)">
+      <Component Id="BlocksRuntime_$(ProductArchitecture)">
+        <File Source="$(RuntimeRoot)\usr\bin\BlocksRuntime.dll" />
+      </Component>
+
+      <Component Id="libdispatch_$(ProductArchitecture)">
+        <File Source="$(RuntimeRoot)\usr\bin\dispatch.dll" />
+      </Component>
+    </Directory>
+  </Module>
+</Wix>


### PR DESCRIPTION
This pull request introduces experimental shared and static runtime installer modules for Windows, with supporting build logic and packaging for multiple architectures. The changes add new WiX project files, update build properties, and integrate these new runtimes into the Windows installer and merge module pipelines.

**Experimental Runtime Packaging and Build Integration**

* Added new WiX project and source files for experimental shared runtime (`rtl.shared.lib.wixproj`, `rtl.shared.lib.wxs`), merge module (`rtl.shared.msm.wixproj`, `rtl.shared.msm.wxs`), and MSI installer (`rtl.shared.msi.wixproj`, `rtl.shared.msi.wxs`), as well as for the static runtime merge module (`rtl.static.msm.wixproj`, `rtl.static.msm.wxs`). These include component definitions for distributing Swift runtime DLLs and utilities for x86, x64, and ARM64 architectures. [[1]](diffhunk://#diff-894391de0592278336e1bef7c88ef3c9186e682f4bcdace3e58735d970e3b7b5R1-R7) [[2]](diffhunk://#diff-4b8b7ec9efc4a3c8a72a24fbf73d9ce3283bb7117c5e785701af9f4bb55b30a2R1-R123) [[3]](diffhunk://#diff-91d3b134ecffb538204c8e6fb48b896a38cb0ff17e7b508da14ceb5e8756c8a5R1-R18) [[4]](diffhunk://#diff-efe24410620347acff95e9abebdb6df1ae29d7b4f6506afdb76e94e9f04481f1R1-R15) [[5]](diffhunk://#diff-4f6fc63e9ce9ad163b289e5edf9fc3762c4919b646ca1c582ce70c2986f225cfR1-R36) [[6]](diffhunk://#diff-a8e1c95b01f777666cc24a503409f2678b2d384c6fb105d2b6ac8b8538095eaeR1-R40) [[7]](diffhunk://#diff-77648ddd516e596e4d8653c97a0b7790a5af8fc2d59bf69e9989569d4e5345f2R1-R6) [[8]](diffhunk://#diff-3b0897afdc48d1d9f6d3938346fea14fbe666d93d33e8b6677a4d65beb3277b6R1-R28)

* Updated `Directory.Build.props` and `SideBySideUpgradeStrategy.props` to add new constants and upgrade codes for the experimental runtimes, enabling them to be referenced and versioned appropriately in the build and installer processes. [[1]](diffhunk://#diff-03bbdfc39931a1bf0faf154b2999cebebf6c89edf59f03b134c0376c0f39d19dR87-R89) [[2]](diffhunk://#diff-2127c12c0e3c017d30287b0e4861837913be44ef7e53b7d7801496c9a5ccc57aR29) [[3]](diffhunk://#diff-2127c12c0e3c017d30287b0e4861837913be44ef7e53b7d7801496c9a5ccc57aR71)

**Installer and Build Pipeline Updates**

* Modified `Directory.Build.targets` to generalize project reference logic and exclude the new runtime modules from unnecessary references, improving build maintainability and reducing redundant dependencies.

* Integrated the new shared and static runtime merge modules into the main Windows installer (`installer.wixproj`) and platform-specific installer projects (`windows.wixproj`), ensuring these experimental runtimes are included for all supported architectures. [[1]](diffhunk://#diff-a254a1cfdde47810b16d45d2dbe4182cad5d177c0cd562f16afe134e2edd9d8bR37-R40) [[2]](diffhunk://#diff-fef3a6c766b63ce1fcdff1300148d8af4634d6185babdcac6faead316512be93R22-R35)