### PR TITLE
WiX: Add the Testing/WinSDK cross-import overlay

### DIFF
--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -327,6 +327,8 @@
     <ComponentGroup Id="Testing">
       <Component Directory="Testing.swiftcrossimport">
         <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\Testing.swiftcrossimport\Foundation.swiftoverlay" />
+      </Component>
+      <Component Directory="Testing.swiftcrossimport">
         <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\Testing.swiftcrossimport\WinSDK.swiftoverlay" />
       </Component>
     </ComponentGroup>
@@ -337,6 +339,8 @@
         </Component>
         <Component Directory="Testing_usr_bin64a" DiskId="2">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\bin64a\_Testing_Foundation.dll" />
+        </Component>
+        <Component Directory="Testing_usr_bin64a" DiskId="2">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\bin64a\_Testing_WinSDK.dll" />
         </Component>
 
@@ -345,6 +349,8 @@
         </Component>
         <Component Directory="Testing_usr_lib_swift_windows_arm64" DiskId="2">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\aarch64\_Testing_Foundation.lib" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_windows_arm64" DiskId="2">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\aarch64\_Testing_WinSDK.lib" />
         </Component>
 
@@ -377,6 +383,8 @@
         </Component>
         <Component Directory="Testing_usr_bin64" DiskId="3">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\bin64\_Testing_Foundation.dll" />
+        </Component>
+        <Component Directory="Testing_usr_bin64" DiskId="3">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\bin64\_Testing_WinSDK.dll" />
         </Component>
 
@@ -385,6 +393,8 @@
         </Component>
         <Component Directory="Testing_usr_lib_swift_windows_x64" DiskId="3">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\x86_64\_Testing_Foundation.lib" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_windows_x64" DiskId="3">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\x86_64\_Testing_WinSDK.lib" />
         </Component>
 
@@ -418,13 +428,17 @@
         <Component Directory="Testing_usr_bin32" DiskId="4">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\bin32\_Testing_Foundation.dll" />
         </Component>
+        <Component Directory="Testing_usr_bin32" DiskId="4">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\bin32\_Testing_WinSDK.dll" />
+        </Component>
 
         <Component Directory="Testing_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\i686\Testing.lib" />
         </Component>
         <Component Directory="Testing_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\i686\_Testing_Foundation.lib" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_windows_x86" DiskId="4">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\windows\i686\_Testing_WinSDK.lib" />
         </Component>
 


### PR DESCRIPTION
Adds the files generated by https://github.com/swiftlang/swift-testing/pull/1296. See also #403 for reference.