### PR TITLE
WiX: Fix single-arch packaging for static experimental SDK

### DIFF
--- a/platforms/Windows/rtl/static/msm/rtl.static.msm.wxs
+++ b/platforms/Windows/rtl/static/msm/rtl.static.msm.wxs
@@ -1,17 +1,17 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
-  <?if $(sys.BUILDARCH) == x86 ?>
+  <?if $(ProductArchitecture) == x86 ?>
     <?define RuntimeDirectoryComponentGuidGenerationSeed = "D3021274-DCA3-4369-82D3-B6CEE436A3FC" ?>
     <?define ModuleID = "53C54287-A59A-4828-A526-4F64E00B340E" ?>
-    <?define RuntimeRoot = $(WindowsExperimentalRuntimeX64)?>
-  <?elseif $(sys.BUILDARCH) == x64 ?>
+    <?define RuntimeRoot = $(WindowsExperimentalRuntimeX86)?>
+  <?elseif $(ProductArchitecture) == x64 ?>
     <?define RuntimeDirectoryComponentGuidGenerationSeed = "639A8564-3505-4424-BA2F-449AAF743A90" ?>
     <?define ModuleID = "F84DDCA4-72B0-42AB-9316-21DBAB241540" ?>
-    <?define RuntimeRoot = $(WindowsExperimentalRuntimeARM64)?>
-  <?elseif $(sys.BUILDARCH) == arm64 ?>
+    <?define RuntimeRoot = $(WindowsExperimentalRuntimeX64)?>
+  <?elseif $(ProductArchitecture) == arm64 ?>
     <?define RuntimeDirectoryComponentGuidGenerationSeed = "F8BF026F-8E3F-42B5-A5E7-E0A4D186EDF3" ?>
     <?define ModuleID = "0439EF46-C6C2-43DF-A5A7-8F4C3F5C64A7" ?>
-    <?define RuntimeRoot = $(WindowsExperimentalRuntimeX86)?>
+    <?define RuntimeRoot = $(WindowsExperimentalRuntimeARM64)?>
   <?endif?>
 
   <Module Guid="$(ModuleID)" Id="swift_runtime" Language="0" Version="$(NonSemVerProductVersion)">

--- a/platforms/Windows/rtl/static/msm/rtl.static.msm.wxs
+++ b/platforms/Windows/rtl/static/msm/rtl.static.msm.wxs
@@ -4,7 +4,7 @@
     <?define RuntimeDirectoryComponentGuidGenerationSeed = "D3021274-DCA3-4369-82D3-B6CEE436A3FC" ?>
     <?define ModuleID = "53C54287-A59A-4828-A526-4F64E00B340E" ?>
     <?define RuntimeRoot = $(WindowsExperimentalRuntimeX86)?>
-  <?elseif $(ProductArchitecture) == x64 ?>
+  <?elseif $(ProductArchitecture) == amd64 ?>
     <?define RuntimeDirectoryComponentGuidGenerationSeed = "639A8564-3505-4424-BA2F-449AAF743A90" ?>
     <?define ModuleID = "F84DDCA4-72B0-42AB-9316-21DBAB241540" ?>
     <?define RuntimeRoot = $(WindowsExperimentalRuntimeX64)?>


### PR DESCRIPTION
This fixes the packaging step for builds like `-WindowsSDKArchitectures "Arm64"`
- When choosing runtime roots, use `ProductArchitecture`, not `sys.BUILDARCH`. `sys.BUILDARCH` derives from `Platform`, which is always x86.
- Updates rotated conditions