### PR TITLE
Use upper case for property names that are passed into the msi

### DIFF
--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -155,14 +155,14 @@
         SourceFile="!(bindpath.rtl)\rtl.msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-        <MsiProperty Name="InstallUtilities" Value="[OptionsInstallUtilities]" />
+        <MsiProperty Name="INSTALLUTILITIES" Value="[OptionsInstallUtilities]" />
       </MsiPackage>
 <?else?>
       <MsiPackage
         SourceFile="!(bindpath.rtl.shared)\rtl.$(ProductArchitecture).msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
-        <MsiProperty Name="InstallUtilities" Value="[OptionsInstallUtilities]" />
+        <MsiProperty Name="INSTALLUTILITIES" Value="[OptionsInstallUtilities]" />
       </MsiPackage>
 <?endif?>
 
@@ -173,10 +173,10 @@
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
 
-          <MsiProperty Name="InstallARM64SDK" Value="[OptionsInstallAndroidSDKARM64]" />
-          <MsiProperty Name="InstallAMD64SDK" Value="[OptionsInstallAndroidSDKAMD64]" />
-          <MsiProperty Name="InstallARMSDK" Value="[OptionsInstallAndroidSDKARM]" />
-          <MsiProperty Name="InstallX86SDK" Value="[OptionsInstallAndroidSDKX86]" />
+          <MsiProperty Name="INSTALLARM64SDK" Value="[OptionsInstallAndroidSDKARM64]" />
+          <MsiProperty Name="INSTALLAMD64SDK" Value="[OptionsInstallAndroidSDKAMD64]" />
+          <MsiProperty Name="INSTALLARMSDK" Value="[OptionsInstallAndroidSDKARM]" />
+          <MsiProperty Name="INSTALLX86SDK" Value="[OptionsInstallAndroidSDKX86]" />
         </MsiPackage>
       <?endif?>
 
@@ -187,14 +187,14 @@
           DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
           <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
 
-          <MsiProperty Name="InstallARM64SDK" Value="[OptionsInstallWindowsSDKARM64]" />
-          <MsiProperty Name="InstallARM64REDIST" Value="[OptionsInstallWindowsRedistARM64]" />
+          <MsiProperty Name="INSTALLARM64SDK" Value="[OptionsInstallWindowsSDKARM64]" />
+          <MsiProperty Name="INSTALLARM64REDIST" Value="[OptionsInstallWindowsRedistARM64]" />
 
-          <MsiProperty Name="InstallAMD64SDK" Value="[OptionsInstallWindowsSDKAMD64]" />
-          <MsiProperty Name="InstallAMD64REDIST" Value="[OptionsInstallWindowsRedistAMD64]" />
+          <MsiProperty Name="INSTALLAMD64SDK" Value="[OptionsInstallWindowsSDKAMD64]" />
+          <MsiProperty Name="INSTALLAMD64REDIST" Value="[OptionsInstallWindowsRedistAMD64]" />
 
-          <MsiProperty Name="InstallX86SDK" Value="[OptionsInstallWindowsSDKX86]" />
-          <MsiProperty Name="InstallX86REDIST" Value="[OptionsInstallWindowsRedistX86]" />
+          <MsiProperty Name="INSTALLX86SDK" Value="[OptionsInstallWindowsSDKX86]" />
+          <MsiProperty Name="INSTALLX86REDIST" Value="[OptionsInstallWindowsRedistX86]" />
         </MsiPackage>
       <?endif?>
      </Chain>

--- a/platforms/Windows/platforms/android/android.wxs
+++ b/platforms/Windows/platforms/android/android.wxs
@@ -2125,7 +2125,7 @@
 
     <?if $(IncludeARM64) = True?>
       <Feature Id="arm64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_arm64)">
-        <Level Condition="InstallARM64SDK = 0" Value="0" />
+        <Level Condition="INSTALLARM64SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="XCTest.arm64" />
         <ComponentGroupRef Id="Testing.arm64" />
@@ -2170,7 +2170,7 @@
 
     <?if $(IncludeARM) = True?>
       <Feature Id="armv7" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_armv7)">
-        <Level Condition="InstallARMSDK = 0" Value="0" />
+        <Level Condition="INSTALLARMSDK = 0" Value="0" />
 
         <ComponentGroupRef Id="XCTest.arm" />
         <ComponentGroupRef Id="Testing.arm" />
@@ -2215,7 +2215,7 @@
 
     <?if $(IncludeX64) = True?>
       <Feature Id="amd64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_amd64)">
-        <Level Condition="InstallAMD64SDK = 0" Value="0" />
+        <Level Condition="INSTALLAMD64SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="XCTest.x64" />
         <ComponentGroupRef Id="Testing.x64" />
@@ -2260,7 +2260,7 @@
 
     <?if $(IncludeX86) = True?>
       <Feature Id="x86" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_x86)">
-        <Level Condition="InstallX86SDK = 0" Value="0" />
+        <Level Condition="INSTALLX86SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="XCTest.x86" />
         <ComponentGroupRef Id="Testing.x86" />

--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -4155,7 +4155,7 @@
 
     <?if $(IncludeARM64) = True?>
       <Feature Display="hidden" Id="arm64.platform" Level="0" Title="!(loc.Plt_ProductName_Windows_arm64)">
-        <Level Condition="InstallARM64SDK = 1 OR InstallARM64ExperimentalSDK = 1" Value="1" />
+        <Level Condition="INSTALLARM64SDK = 1 OR INSTALLARM64EXPERIMENTALSDK = 1" Value="1" />
 
         <ComponentGroupRef Id="XCTest.arm64" />
         <ComponentGroupRef Id="Testing.arm64" />
@@ -4164,7 +4164,7 @@
 
     <?if $(IncludeX64) = True?>
       <Feature Display="hidden" Id="x64.platform" Level="0" Title="!(loc.Plt_ProductName_Windows_amd64)">
-        <Level Condition="InstallAMD64SDK = 1 OR InstallAMD64ExperimentalSDK = 1" Value="1" />
+        <Level Condition="INSTALLAMD64SDK = 1 OR INSTALLAMD64EXPERIMENTALSDK = 1" Value="1" />
 
         <ComponentGroupRef Id="XCTest.x64" />
         <ComponentGroupRef Id="Testing.x64" />
@@ -4173,7 +4173,7 @@
 
     <?if $(IncludeX86) = True?>
       <Feature Display="hidden" Id="x86.platform" Level="0" Title="!(loc.Plt_ProductName_Windows_x86)">
-        <Level Condition="InstallX86SDK = 1 OR InstallX86ExperimentalSDK = 1" Value="1" />
+        <Level Condition="INSTALLX86SDK = 1 OR INSTALLX86EXPERIMENTALSDK = 1" Value="1" />
 
         <ComponentGroupRef Id="XCTest.x86" />
         <ComponentGroupRef Id="Testing.x86" />
@@ -4197,7 +4197,7 @@
 
     <?if $(IncludeARM64) = True?>
       <Feature Id="arm64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Windows_arm64)">
-        <Level Condition="InstallARM64SDK = 0" Value="0" />
+        <Level Condition="INSTALLARM64SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="LegacySwiftRemoteMirror.arm64" />
 
@@ -4238,7 +4238,7 @@
 
     <?if $(IncludeX64) = True?>
       <Feature Id="x64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Windows_amd64)">
-        <Level Condition="InstallAMD64SDK = 0" Value="0" />
+        <Level Condition="INSTALLAMD64SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="LegacySwiftRemoteMirror.x64" />
 
@@ -4279,7 +4279,7 @@
 
     <?if $(IncludeX86) = True?>
       <Feature Id="x86" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Windows_x86)">
-        <Level Condition="InstallX86SDK = 0" Value="0" />
+        <Level Condition="INSTALLX86SDK = 0" Value="0" />
 
         <ComponentGroupRef Id="LegacySwiftRemoteMirror.x86" />
 
@@ -4334,7 +4334,7 @@
 
     <?if $(IncludeARM64) = True?>
       <Feature Id="ExperimentalARM64" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_arm64)">
-        <Level Condition="InstallARM64ExperimentalSDK = 1" Value="1" />
+        <Level Condition="INSTALLARM64EXPERIMENTALSDK = 1" Value="1" />
 
         <ComponentGroupRef Id="BlocksRuntime.arm64" />
         <ComponentGroupRef Id="CRT.arm64" />
@@ -4405,7 +4405,7 @@
 
     <?if $(IncludeX64) = True?>
       <Feature Id="ExperimentalX64" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_amd64)">
-        <Level Condition="InstallX64ExperimentalSDK = 1" Value="1" />
+        <Level Condition="INSTALLX64EXPERIMENTALSDK = 1" Value="1" />
 
         <ComponentGroupRef Id="BlocksRuntime.x64" />
         <ComponentGroupRef Id="CRT.x64" />
@@ -4476,7 +4476,7 @@
 
     <?if $(IncludeX86) = True?>
       <Feature Id="ExperimentalX86" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Windows_Experimental_x86)">
-        <Level Condition="InstallX86ExperimentalSDK = 1" Value="1" />
+        <Level Condition="INSTALLX86EXPERIMENTALSDK = 1" Value="1" />
 
         <ComponentGroupRef Id="BlocksRuntime.x86" />
         <ComponentGroupRef Id="CRT.x86" />


### PR DESCRIPTION
MSI uses property name case to define scope. Public properties (i.e., can be set from outside the MSI, e.g., command line) are all uppercase, and ones set within the installer are lowercase. See more in the [official docs](https://learn.microsoft.com/en-us/windows/win32/msi/public-properties?redirectedfrom=MSDN)

Since we are passing these properties to the MSI from the chainer, they need to be uppercase when they are being read. I have also changed the setting side to make sure we are consistent and do not run into this issue again.