### PR TITLE
Windows: add property to verbose log when signing

### DIFF
--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <SignOutput Condition=" '$(SignOutput)' == '' ">false</SignOutput>
     <SignOutput>$(SignOutput)</SignOutput>
+    <SignToolVerbose Condition=" '$(SignToolVerbose)' == '' ">false</SignToolVerbose>
   </PropertyGroup>
 
   <Target Name="FindSignTool">
@@ -28,6 +29,9 @@
       <!-- Windows 8.1 SDKS -->
       <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\x64\signtool.exe')">$(WindowsKitsRoot)bin\x64\</SignToolPath>
 
+      <VerboseFlag Condition=" '$(SignToolVerbose)' == 'true' ">/v </VerboseFlag>
+      <VerboseFlag Condition=" '$(SignToolVerbose)' != 'true' "></VerboseFlag>
+
       <!-- Windows 11 SDKs -->
       <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.22621.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22621.0\arm64\</SignToolPath>
       <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.22000.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22000.0\arm64\</SignToolPath>
@@ -44,8 +48,8 @@
       <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.10240.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10240.0\arm64\</SignToolPath>
 
       <!-- Microsoft recommends using their timestamp server for trusted signing: https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations#:~:text=Trusted%20Signing%20certificates,microsoft.com/-->
-      <SignTool Condition=" '$(AzureSignMetadata)' != '' ">"$(SignToolPath)signtool.exe" sign /v /tr http://timestamp.acs.microsoft.com /fd sha256 /td sha256 /dlib "$(AzureSignDlib)" /dmdf "$(AzureSignMetadata)"</SignTool>
-      <SignTool Condition=" '$(AzureSignMetadata)' == '' ">"$(SignToolPath)signtool.exe" sign /v /tr http://timestamp.digicert.com /fd sha256 /td sha256 /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" </SignTool>
+      <SignTool Condition=" '$(AzureSignMetadata)' != '' ">"$(SignToolPath)signtool.exe" sign $(VerboseFlag)/tr http://timestamp.acs.microsoft.com /fd sha256 /td sha256 /dlib "$(AzureSignDlib)" /dmdf "$(AzureSignMetadata)"</SignTool>
+      <SignTool Condition=" '$(AzureSignMetadata)' == '' ">"$(SignToolPath)signtool.exe" sign $(VerboseFlag)/tr http://timestamp.digicert.com /fd sha256 /td sha256 /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" </SignTool>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
We're seeing flaky failures on CI from trusted signing. When I saw this locally, adding logging "fixed" it (suggesting a race condition). This change adds a property that lets us turn it on, both to see if it's sufficient and to learn something if it's not.