### PR TITLE
WiX: ingest the MSI redistributable in the toolchain

### DIFF
--- a/platforms/Windows/Directory.Build.props
+++ b/platforms/Windows/Directory.Build.props
@@ -84,13 +84,14 @@
       ArePackageCabsEmbedded=$(ArePackageCabsEmbedded);
       BaseReleaseDownloadUrl=$(BaseReleaseDownloadUrl);
       ImageRoot=$(ImageRoot);
+      RedistributablesDirectory=$(RedistributablesDirectory);
+      IncludeLegacySDK=$(IncludeLegacySDK);
       WindowsRuntimeARM64=$(WindowsRuntimeARM64);
       WindowsRuntimeX64=$(WindowsRuntimeX64);
       WindowsRuntimeX86=$(WindowsRuntimeX86);
       WindowsExperimentalRuntimeARM64=$(WindowsExperimentalRuntimeARM64);
       WindowsExperimentalRuntimeX64=$(WindowsExperimentalRuntimeX64);
       WindowsExperimentalRuntimeX86=$(WindowsExperimentalRuntimeX86);
-      IncludeLegacySDK=$(IncludeLegacySDK);
     </DefineConstants>
   </PropertyGroup>
 

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
+  <?if $(sys.BUILDARCH) == x64 ?>
+    <?define MergeModuleFileName = "rtl.amd64.msm" ?>
+  <?else?>
+    <?define MergeModuleFileName = "rtl.$(sys.BUILDARCH).msm" ?>
+  <?endif?>
+
   <Package
       Language="1033"
       Manufacturer="!(loc.ManufacturerName)"
@@ -33,6 +39,10 @@
           </Directory>
         </Directory>
       </Directory>
+    </DirectoryRef>
+
+    <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
+      <Merge DiskId="1" Id="swift_runtime" Language="0" SourceFile="$(RedistributablesDirectory)\$(MergeModuleFileName)" />
     </DirectoryRef>
 
     <ComponentGroup Id="cmark_gfm" Directory="toolchain_$(VariantName)_usr_bin">
@@ -210,30 +220,6 @@
       <Component>
         <File Source="$(ToolchainRoot)\usr\bin\lld.exe" />
       </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="BlocksRuntime">
-      <Component Directory="toolchain_$(VariantName)_usr_bin">
-        <File Source="$(ToolchainRoot)\usr\bin\BlocksRuntime.dll" />
-      </Component>
-
-      <Component Directory="toolchain_$(VariantName)_usr_lib">
-        <File Source="$(ToolchainRoot)\usr\lib\BlocksRuntime.lib" />
-      </Component>
-
-      <!-- TODO(compnerd) should we install the block headers? -->
-    </ComponentGroup>
-
-    <ComponentGroup Id="libdispatch">
-      <Component Directory="toolchain_$(VariantName)_usr_bin">
-        <File Source="$(ToolchainRoot)\usr\bin\dispatch.dll" />
-      </Component>
-
-      <Component Directory="toolchain_$(VariantName)_usr_lib">
-        <File Source="$(ToolchainRoot)\usr\lib\dispatch.lib" />
-      </Component>
-
-      <!-- TODO(compnerd) should we install the dispatch headers? -->
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftCxx" Directory="toolchain_$(VariantName)_usr_lib_swift_swiftToCxx">
@@ -551,6 +537,10 @@
       </Component>
     </ComponentGroup>
 
+    <Feature Id="SwiftRuntimeRedistributable" Title="Swift Runtime Redistributable" AllowAdvertise="no" Display="hidden" Level="1">
+      <MergeRef Id="swift_runtime" />
+    </Feature>
+
     <Feature Id="BuildTools" AllowAbsent="no" Title="$(VariantProductName)">
       <ComponentGroupRef Id="cmark_gfm" />
 
@@ -558,8 +548,6 @@
       <ComponentGroupRef Id="lto" />
       <ComponentGroupRef Id="clang" />
       <ComponentGroupRef Id="lld" />
-      <ComponentGroupRef Id="BlocksRuntime" />
-      <ComponentGroupRef Id="libdispatch" />
       <ComponentGroupRef Id="swift" />
       <ComponentGroupRef Id="argument_parser" />
       <ComponentGroupRef Id="tools_support_core" />

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -32,7 +32,8 @@
     <Variable Name="OptionsInstallCLI" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallDBG" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallIDE" bal:Overridable="yes" Persisted="yes" Value="1" />
-    <Variable Name="OptionsInstallRTL" Value="1" />
+    <!-- TODO(compnerd) enable installing non-native RTL (e.g. X64 on ARM64) -->
+    <Variable Name="OptionsInstallRTL" bal:Overridable="yes" Persisted="yes" Value="1" />
 
     <Variable Name="OptionsInstallUtilities" bal:Overridable="yes" Persisted="yes" Value="1" />
 

--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -60,7 +60,7 @@
             <Checkbox Name="OptionsInstallCLI" X="192" Y="129" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallDBG" X="192" Y="147" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallIDE" X="192" Y="165" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallRTL" X="192" Y="183" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Rtl_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallRTL" X="192" Y="183" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallRTL">#(loc.Rtl_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallWindowsPlatform" X="192" Y="201" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Plt_ProductName_Windows)</Checkbox>
             <Checkbox Name="OptionsInstallWindowsSDKAMD64" X="210" Y="219" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_amd64)</Checkbox>
             <Checkbox Name="OptionsInstallWindowsRedistAMD64" X="228" Y="237" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKAMD64">#(loc.Redist_amd64)</Checkbox>


### PR DESCRIPTION
With the ability to install the runtime with SxS manifesting, we now properly build the toolchain against a previous runtime which is isolated from the SDK associated runtime. In order to support this model, we must ingest the redistributable and package that into the toolchain.