### PR TITLE
WiX: add upgrade code for 6.3 release

### DIFF
--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -55,6 +55,10 @@
     <BundleUpgradeCode>{E41E5E4A-6DA1-435A-A1DC-7CB3E14664F4}</BundleUpgradeCode>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MajorMinorProductVersion)' == '6.3'">
+    <BundleUpgradeCode>{4006953D-4D1C-42EE-B7E5-66264DE40EA1}</BundleUpgradeCode>
+  </PropertyGroup>
+
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);


### PR DESCRIPTION
Introduce the 6.3 release cycle by adding the upgrade code.