### PR TITLE
WiX: clean up the python packaging

### DIFF
--- a/platforms/Windows/python/python.wxs
+++ b/platforms/Windows/python/python.wxs
@@ -21,10 +21,17 @@
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
     <DirectoryRef Id="INSTALLROOT">
-      <Directory Id="python" Name="Python-$(PythonVersion)" />
+      <Directory Id="python" Name="Python-$(PythonVersion)">
+        <Directory Id="_usr" Name="usr">
+          <Directory Id="_usr_bin" Name="bin" />
+          <Directory Id="_usr_share" Name="share">
+            <Directory Id="_usr_share_licenses" Name="licenses" />
+          </Directory>
+        </Directory>
+      </Directory>
     </DirectoryRef>
 
-    <ComponentGroup Id="EmbeddedPython" Directory="python">
+    <ComponentGroup Id="EmbeddedPython" Directory="_usr_bin">
       <Component>
         <File Source="$(PythonRoot)\libcrypto-1_1$(ArchSuffix).dll" />
       </Component>
@@ -124,17 +131,14 @@
       <Component>
         <File Source="$(PythonRoot)\_zoneinfo.pyd" />
       </Component>
-    </ComponentGroup>
 
-    <ComponentGroup Id="EmbeddedPythonLicense">
-      <Component Directory="toolchain_asserts_usr_share_licenses">
-        <File Source="$(PythonRoot)\LICENSE.txt" />
+      <Component Directory="_usr_share_licenses">
+        <File Name="python.txt" Source="$(PythonRoot)\LICENSE.txt" />
       </Component>
     </ComponentGroup>
 
     <Feature Id="EmbeddedPython" AllowAbsent="no" Title="$(VariantProductName)">
       <ComponentGroupRef Id="EmbeddedPython" />
-      <ComponentGroupRef Id="EmbeddedPythonLicense" />
     </Feature>
   </Package>
 </Wix>

--- a/platforms/Windows/shared/shared.wxs
+++ b/platforms/Windows/shared/shared.wxs
@@ -55,7 +55,6 @@
                 <Directory Id="toolchain_asserts_usr_share_docc" Name="docc">
                   <Directory Id="toolchain_asserts_usr_share_docc_render" Name="render" />
                 </Directory>
-                <Directory Id="toolchain_asserts_usr_share_licenses" Name="licenses" />
               </Directory>
             </Directory>
           </Directory>


### PR DESCRIPTION
Restructure the python installation to mimic the Unix style layout that we use throughout the components. Specifically, migrate the .exe and .dll files into a `/usr/bin` subdirectory under the installation and move the license into the package itself.