### PR TITLE
WiX: adjust the install rules for SK-LSP

### DIFF
--- a/platforms/Windows/ide/ide.wxi
+++ b/platforms/Windows/ide/ide.wxi
@@ -40,11 +40,11 @@
       </Component>
 
       <Component Directory="toolchain_$(VariantName)_usr_bin">
-        <File Source="$(ToolchainRoot)\usr\lib\SwiftSourceKitPlugin.dll" />
+        <File Source="$(ToolchainRoot)\usr\bin\SwiftSourceKitPlugin.dll" />
       </Component>
 
       <Component Directory="toolchain_$(VariantName)_usr_bin">
-        <File Source="$(ToolchainRoot)\usr\lib\SwiftSourceKitClientPlugin.dll" />
+        <File Source="$(ToolchainRoot)\usr\bin\SwiftSourceKitClientPlugin.dll" />
       </Component>
 
       <Component Directory="toolchain_$(VariantName)_usr_include_SourceKit">


### PR DESCRIPTION
Account for the appropriate install location for the SourceKit plugins.