### PR TITLE
Add WindowsStripSymbols.xcspec to install rules

### DIFF
--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -626,6 +626,9 @@
       <Component>
         <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWindowsPlatform.resources\WindowsLibtool.xcspec" />
       </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBWindowsPlatform.resources\WindowsStripSymbols.xcspec" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftBuild" Directory="toolchain_$(VariantName)_usr_bin">


### PR DESCRIPTION
Depends on swiftlang/swift-build#1085