### PR TITLE
WiX: package the swift-backtrace tool in the experimental SDK

### DIFF
--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -35,6 +35,7 @@
     <Variable Name="OptionsInstallIDE" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallRTL" Value="1" />
 
+    <Variable Name="OptionsInstallSupport" bal:Overridable="yes" Persisted="yes" Value="1" />
     <Variable Name="OptionsInstallUtilities" bal:Overridable="yes" Persisted="yes" Value="1" />
 
     <Variable Name="OptionsInstallWindowsPlatform" bal:Overridable="yes" Persisted="yes" Value="1" />
@@ -163,6 +164,7 @@
         SourceFile="!(bindpath.rtl)\rtl.msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        <MsiProperty Name="INSTALLSUPPORT" Value="[OptionsInstallSupport]" />
         <MsiProperty Name="INSTALLUTILITIES" Value="[OptionsInstallUtilities]" />
       </MsiPackage>
 <?else?>
@@ -170,6 +172,7 @@
         SourceFile="!(bindpath.rtl.shared)\rtl.$(ProductArchitecture).msi"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        <MsiProperty Name="INSTALLSUPPORT" Value="[OptionsInstallSupport]" />
         <MsiProperty Name="INSTALLUTILITIES" Value="[OptionsInstallUtilities]" />
       </MsiPackage>
 <?endif?>

--- a/platforms/Windows/rtl/legacy/lib/rtllib.wxs
+++ b/platforms/Windows/rtl/legacy/lib/rtllib.wxs
@@ -71,13 +71,6 @@
       <Component>
         <File Source="$(RuntimeRoot)\usr\bin\swiftWinSDK.dll" />
       </Component>
-
-      <!-- TODO(hjyamauchi) enable this when we build this for x86 https://github.com/swiftlang/swift/issues/87499 -->
-      <?if $(ProductArchitecture) != x86?>
-        <Component Directory="LIBEXECDIR_$(ProductArchitecture)">
-          <File Source="$(RuntimeRoot)\usr\libexec\swift\windows\swift-backtrace.exe" />
-        </Component>
-      <?endif?>
     </ComponentGroup>
 
     <ComponentGroup Id="BlocksRuntime_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
@@ -122,12 +115,28 @@
       </Component>
     </ComponentGroup>
 
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <ComponentGroup Id="swift_backtrace_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component Directory="LIBEXECDIR_$(ProductArchitecture)">
+        <File Source="$(RuntimeRoot)\usr\libexec\swift\windows\swift-backtrace.exe" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
     <ComponentGroup Id="swift_runtime_$(ProductArchitecture)">
       <ComponentGroupRef Id="stdlib_$(ProductArchitecture)" />
       <ComponentGroupRef Id="BlocksRuntime_$(ProductArchitecture)" />
       <ComponentGroupRef Id="libdispatch_$(ProductArchitecture)" />
       <ComponentGroupRef Id="Foundation_$(ProductArchitecture)" />
     </ComponentGroup>
+
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <ComponentGroup Id="swift_runtime_support_$(ProductArchitecture)">
+      <ComponentGroupRef Id="swift_backtrace_$(ProductArchitecture)" />
+    </ComponentGroup>
+    <?endif?>
 
     <ComponentGroup Id="swift_runtime_utilities_$(ProductArchitecture)">
       <ComponentGroupRef Id="plutil_$(ProductArchitecture)" />

--- a/platforms/Windows/rtl/legacy/msi/rtlmsi.wxs
+++ b/platforms/Windows/rtl/legacy/msi/rtlmsi.wxs
@@ -35,6 +35,14 @@
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
 
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <Feature Id="SwiftRuntimeSupport" AllowAbsent="yes" Title="!(loc.Sup_ProductName_$(ProductArchitecture))">
+      <Level Condition="INSTALLSUPPORT = 0" Value="0" />
+      <ComponentGroupRef Id="swift_runtime_support_$(ProductArchitecture)" />
+    </Feature>
+    <?endif?>
+
     <Feature Id="SwiftRuntimeUtilities" AllowAbsent="yes" Title="!(loc.Utl_ProductName_$(ProductArchitecture))">
       <Level Condition="INSTALLUTILITIES = 0" Value="0" />
       <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />

--- a/platforms/Windows/rtl/legacy/msm/rtlmsm.wxs
+++ b/platforms/Windows/rtl/legacy/msm/rtlmsm.wxs
@@ -15,6 +15,10 @@
     Version="$(NonSemVerProductVersion)">
 
     <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <ComponentGroupRef Id="swift_runtime_support_$(ProductArchitecture)" />
+    <?endif?>
     <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />
   </Module>
 </Wix>

--- a/platforms/Windows/rtl/shared/lib/rtl.shared.lib.wxs
+++ b/platforms/Windows/rtl/shared/lib/rtl.shared.lib.wxs
@@ -13,6 +13,7 @@
       <?define LibexecDirectoryComponentGuidGenerationSeed = "FCAC627D-44EC-4745-B81B-E12CE8F80951" ?>
       <?define RuntimeRoot = $(WindowsExperimentalRuntimeX86)?>
     <?endif?>
+    <?define SDKRoot = "$(ImageRoot)\Platforms\Windows.platform\Developer\SDKs\WindowsExperimental.sdk"?>
 
     <Directory Id="RUNTIMEDIR_$(ProductArchitecture)" ComponentGuidGenerationSeed="$(RuntimeDirectoryComponentGuidGenerationSeed)" />
     <Directory Id="LIBEXECDIR_$(ProductArchitecture)" ComponentGuidGenerationSeed="$(LibexecDirectoryComponentGuidGenerationSeed)" />
@@ -67,12 +68,6 @@
         <File Source="$(RuntimeRoot)\usr\bin\swift_Volatile.dll" />
       </Component>
 
-      <!-- TODO Enable when the experimental Runtimes build builds swift-backtrace
-      <Component Directory="LIBEXECDIR_$(ProductArchitecture)">
-        <File Source="$(RuntimeRoot)\usr\libexec\swift\windows\swift-backtrace.exe" />
-      </Component>
-      -->
-
       <!-- TODO(compnerd) should we distribute the undecoration library in the runtime?
       <Component Directory="_usr_bin" Id="swiftDemangle.dll">
         <File Id="swiftDemangle.dll" Source="$(RuntimeRoot)\bin\swiftDemangle.dll" />
@@ -122,12 +117,28 @@
       </Component>
     </ComponentGroup>
 
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <ComponentGroup Id="swift_backtrace_$(ProductArchitecture)" Directory="RUNTIMEDIR_$(ProductArchitecture)">
+      <Component Directory="LIBEXECDIR_$(ProductArchitecture)">
+        <File Source="$(SDKRoot)\usr\libexec\swift\swift-backtrace.exe" />
+      </Component>
+    </ComponentGroup>
+    <?endif?>
+
     <ComponentGroup Id="swift_runtime_$(ProductArchitecture)">
       <ComponentGroupRef Id="stdlib_$(ProductArchitecture)" />
       <ComponentGroupRef Id="BlocksRuntime_$(ProductArchitecture)" />
       <ComponentGroupRef Id="libdispatch_$(ProductArchitecture)" />
       <ComponentGroupRef Id="Foundation_$(ProductArchitecture)" />
     </ComponentGroup>
+
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <ComponentGroup Id="swift_runtime_support_$(ProductArchitecture)">
+      <ComponentGroupRef Id="swift_backtrace_$(ProductArchitecture)" />
+    </ComponentGroup>
+    <?endif?>
 
     <ComponentGroup Id="swift_runtime_utilities_$(ProductArchitecture)">
       <ComponentGroupRef Id="plutil_$(ProductArchitecture)" />

--- a/platforms/Windows/rtl/shared/msi/rtl.shared.msi.wxs
+++ b/platforms/Windows/rtl/shared/msi/rtl.shared.msi.wxs
@@ -34,6 +34,14 @@
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
 
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <Feature Id="SwiftRuntimeSupport" AllowAbsent="yes" Title="!(loc.Sup_ProductName_$(ProductArchitecture))">
+      <Level Condition="INSTALLSUPPORT = 0" Value="0" />
+      <ComponentGroupRef Id="swift_runtime_support_$(ProductArchitecture)" />
+    </Feature>
+    <?endif?>
+
     <Feature Id="SwiftRuntimeUtilities" AllowAbsent="yes" Title="!(loc.Utl_ProductName_$(ProductArchitecture))">
       <Level Condition="INSTALLUTILITIES = 0" Value="0" />
       <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />

--- a/platforms/Windows/rtl/shared/msm/rtl.shared.msm.wxs
+++ b/platforms/Windows/rtl/shared/msm/rtl.shared.msm.wxs
@@ -10,6 +10,10 @@
 
   <Module Guid="$(ModuleId)" Id="swift_runtime" Language="0" Version="$(NonSemVerProductVersion)">
     <ComponentGroupRef Id="swift_runtime_$(ProductArchitecture)" />
+    <!-- TODO(https://github.com/swiftlang/swift/issues/87499 ) enable this when we build this for x86 -->
+    <?if $(ProductArchitecture) != x86?>
+    <ComponentGroupRef Id="swift_runtime_support_$(ProductArchitecture)" />
+    <?endif?>
     <ComponentGroupRef Id="swift_runtime_utilities_$(ProductArchitecture)" />
   </Module>
 </Wix>

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -38,6 +38,9 @@
   <String Id="Plt_ProductName_Windows_Experimental_arm64" Value="Swift Windows Platform Support (ARM64) [Experimental]" />
   <String Id="Plt_ProductName_Windows_Experimental_amd64" Value="Swift Windows Platform Support (AMD64) [Experimental]" />
   <String Id="Plt_ProductName_Windows_Experimental_x86" Value="Swift Windows Platform Support (X86) [Experimental]" />
+  <String Id="Sup_ProductName_arm64" Value="Swift Runtime Support (ARM64)" />
+  <String Id="Sup_ProductName_amd64" Value="Swift Runtime Support (AMD64)" />
+  <String Id="Sup_ProductName_x86" Value="Swift Runtime Support (X86)" />
   <String Id="Utl_ProductName_arm64" Value="Swift Windows Utilities (ARM64)" />
   <String Id="Utl_ProductName_amd64" Value="Swift Windows Utilities (AMD64)" />
   <String Id="Utl_ProductName_x86" Value="Swift Windows Utilities (X86)" />


### PR DESCRIPTION
The redistribution should include the backtrace tool. We have a hidden
knob to permit exclusion, but we do not surface this in the installer UI.
We expect most use cases to distribute the tool as part of the runtime
and would like to encourage its use.