### PR TITLE
WiX: correct installer layout

### DIFF
--- a/platforms/Windows/bundle/theme.xml
+++ b/platforms/Windows/bundle/theme.xml
@@ -14,8 +14,8 @@
         <Label X="192" Y="11" Width="-11" Height="32" FontId="1" DisablePrefix="yes">#(loc.Title)</Label>
 
         <Page Name="Help">
-            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Label>
-            <Label X="176" Y="91" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Label>
+            <Label X="192" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Label>
+            <Label X="192" Y="91" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Label>
             <Button Name="HelpCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.HelpCloseButton)</Text>
                 <CloseWindowAction />
@@ -23,18 +23,18 @@
         </Page>
 
         <Page Name="Loading">
-            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes" Visible="no" Name="CheckingForUpdatesLabel" />
+            <Label X="192" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes" Visible="no" Name="CheckingForUpdatesLabel" />
         </Page>
 
         <Page Name="Install">
-            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.InstallHeader)</Label>
-            <Label X="176" Y="91" Width="-11" Height="64" FontId="3" DisablePrefix="yes">
+            <Label X="192" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.InstallHeader)</Label>
+            <Label X="192" Y="91" Width="-11" Height="64" FontId="3" DisablePrefix="yes">
                 <Text Condition="WixStdBASuppressOptionsUI">#(loc.InstallMessage)</Text>
                 <Text Condition="NOT WixStdBASuppressOptionsUI">#(loc.InstallMessageOptions)</Text>
             </Label>
-            <Hypertext Name="EulaHyperlink" X="176" Y="-73" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
-            <Label Name="InstallVersion" X="176" Y="-103" Width="-11" Height="17" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">#(loc.InstallVersion)</Label>
-            <Checkbox Name="EulaAcceptCheckbox" X="176" Y="-51" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
+            <Hypertext Name="EulaHyperlink" X="192" Y="-73" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
+            <Label Name="InstallVersion" X="192" Y="-103" Width="-11" Height="17" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">#(loc.InstallVersion)</Label>
+            <Checkbox Name="EulaAcceptCheckbox" X="192" Y="-51" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
             <Button Name="InstallUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
             <Button Name="OptionsButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" VisibleCondition="NOT WixStdBASuppressOptionsUI">
                 <Text>#(loc.InstallOptionsButton)</Text>
@@ -48,32 +48,32 @@
         </Page>
 
         <Page Name="Options">
-            <Label X="176" Y="46" Width="-11" Height="20" FontId="2" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Label>
-            <Editbox Name="InstallRoot" X="176" Y="70" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
+            <Label X="192" Y="46" Width="-11" Height="20" FontId="2" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Label>
+            <Editbox Name="InstallRoot" X="192" Y="70" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
             <Button Name="BrowseButton" X="-11" Y="69" Width="75" Height="23" TabStop="yes" FontId="3">
                 <Text>#(loc.OptionsBrowseButton)</Text>
                 <BrowseDirectoryAction VariableName="InstallRoot" />
             </Button>
 
-            <Label X="176" Y="88" Width="-11" Height="20" FontId="2" DisablePrefix="yes">#(loc.OptionsFeaturesLabel)</Label>
-            <Checkbox Name="OptionsInstallBLD" X="176" Y="111" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Bld_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallCLI" X="176" Y="129" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallDBG" X="176" Y="147" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
+            <Label X="192" Y="88" Width="-11" Height="20" FontId="2" DisablePrefix="yes">#(loc.OptionsFeaturesLabel)</Label>
+            <Checkbox Name="OptionsInstallBLD" X="192" Y="111" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Bld_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallCLI" X="192" Y="129" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Cli_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallDBG" X="192" Y="147" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Dbg_ProductName)</Checkbox>
             <Checkbox Name="OptionsInstallPy" X="210" Y="165" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallDBG">#(loc.EmbeddedPython_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallIDE" X="176" Y="165" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallRTL" X="176" Y="183" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Rtl_ProductName)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsPlatform" X="176" Y="201" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Plt_ProductName_Windows)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsSDKAMD64" X="194" Y="219" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsRedistAMD64" X="212" Y="237" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKAMD64">#(loc.Redist_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsSDKARM64" X="194" Y="255" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsRedistARM64" X="212" Y="273" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKARM64">#(loc.Redist_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsSDKX86" X="194" Y="291" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallWindowsRedistX86" X="212" Y="309" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKX86">#(loc.Redist_x86)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidPlatform" X="176" Y="327" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Plt_ProductName_Android)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSDKARM64" X="194" Y="345" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_arm64)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSDKAMD64" X="194" Y="363" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_amd64)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSDKARM" X="194" Y="381" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_armv7)</Checkbox>
-            <Checkbox Name="OptionsInstallAndroidSDKX86" X="194" Y="399" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallIDE" X="192" Y="183" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Ide_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallRTL" X="192" Y="201" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="0">#(loc.Rtl_ProductName)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsPlatform" X="192" Y="219" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Plt_ProductName_Windows)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsSDKAMD64" X="210" Y="237" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsRedistAMD64" X="228" Y="255" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKAMD64">#(loc.Redist_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsSDKARM64" X="210" Y="273" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsRedistARM64" X="228" Y="291" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKARM64">#(loc.Redist_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsSDKX86" X="210" Y="309" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform">#(loc.Sdk_ProductName_Windows_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallWindowsRedistX86" X="228" Y="327" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallWindowsPlatform AND OptionsInstallWindowsSDKX86">#(loc.Redist_x86)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidPlatform" X="192" Y="345" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.Plt_ProductName_Android)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKARM64" X="210" Y="363" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_arm64)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKAMD64" X="210" Y="381" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_amd64)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKARM" X="210" Y="399" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_armv7)</Checkbox>
+            <Checkbox Name="OptionsInstallAndroidSDKX86" X="210" Y="417" Width="-11" Height="17" TabStop="yes" FontId="3" EnableCondition="OptionsInstallAndroidPlatform">#(loc.Sdk_ProductName_Android_x86)</Checkbox>
 
             <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.OptionsOkButton)</Text>
@@ -86,14 +86,14 @@
         </Page>
 
         <Page Name="Progress">
-            <Label X="176" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
-            <Label Name="OverallProgressPackageText" X="176" Y="89" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
-            <Progressbar Name="OverallCalculatedProgressbar" X="176" Y="111" Width="-11" Height="20" />
+            <Label X="192" Y="50" Width="-11" Height="32" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
+            <Label Name="OverallProgressPackageText" X="192" Y="89" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
+            <Progressbar Name="OverallCalculatedProgressbar" X="192" Y="111" Width="-11" Height="20" />
             <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
         </Page>
 
         <Page Name="Modify">
-            <Label X="176" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Label>
+            <Label X="192" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Label>
             <Button Name="ModifyUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
             <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
             <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
@@ -104,7 +104,7 @@
         </Page>
 
         <Page Name="Success">
-            <Label X="176" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
+            <Label X="192" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
                 <Text>#(loc.SuccessHeader)</Text>
                 <Text Condition="WixBundleAction = 2">#(loc.SuccessLayoutHeader)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.SuccessUnsafeUninstallHeader)</Text>
@@ -115,7 +115,7 @@
                 <Text Condition="WixBundleAction = 8">#(loc.SuccessRepairHeader)</Text>
             </Label>
             <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
-            <Label X="176" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
+            <Label X="192" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
                 <Text>#(loc.SuccessRestartText)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.SuccessUninstallRestartText)</Text>
             </Label>
@@ -127,7 +127,7 @@
         </Page>
 
         <Page Name="Failure">
-            <Label X="176" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
+            <Label X="192" Y="50" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
                 <Text>#(loc.FailureHeader)</Text>
                 <Text Condition="WixBundleAction = 2">#(loc.FailureLayoutHeader)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.FailureUnsafeUninstallHeader)</Text>
@@ -137,9 +137,9 @@
                 <Text Condition="WixBundleAction = 7">#(loc.FailureModifyHeader)</Text>
                 <Text Condition="WixBundleAction = 8">#(loc.FailureRepairHeader)</Text>
             </Label>
-            <Hypertext Name="FailureLogFileLink" X="176" Y="121" Width="-11" Height="68" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
-            <Hypertext Name="FailureMessageText" X="176" Y="-115" Width="-11" Height="80" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
-            <Label X="176" Y="-57" Width="-11" Height="80" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
+            <Hypertext Name="FailureLogFileLink" X="192" Y="121" Width="-11" Height="68" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
+            <Hypertext Name="FailureMessageText" X="192" Y="-115" Width="-11" Height="80" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
+            <Label X="192" Y="-57" Width="-11" Height="80" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
             <Button Name="FailureRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
             <Button Name="FailureCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.FailureCloseButton)</Text>


### PR DESCRIPTION
Update the layout to fix the rendering of the installer pages after the incorrect merge for the embedded python.