### PR TITLE
WiX: adjust the Android SDK packaging

### DIFF
--- a/platforms/Windows/platforms/android/android.wxs
+++ b/platforms/Windows/platforms/android/android.wxs
@@ -16,18 +16,18 @@
     <?define PlatformRoot = "$(ImageRoot)\Platforms\Android.platform"?>
     <?define SDKRoot = "$(PlatformRoot)\Developer\SDKs\Android.sdk"?>
 
-    <Media Id="1" Cabinet="android.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+    <Media Id="5" Cabinet="android.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?if $(IncludeARM64) = True?>
-      <Media Id="2" Cabinet="sdk.android.arm64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="6" Cabinet="sdk.android.arm64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
     <?if $(IncludeARM) = True?>
-      <Media Id="3" Cabinet="sdk.android.arm.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="7" Cabinet="sdk.android.arm.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
     <?if $(IncludeX64) = True?>
-      <Media Id="4" Cabinet="sdk.android.x64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="8" Cabinet="sdk.android.x64.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
     <?if $(IncludeX86) = True?>
-      <Media Id="5" Cabinet="sdk.android.x86.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
+      <Media Id="9" Cabinet="sdk.android.x86.cab" EmbedCab="$(ArePackageCabsEmbedded)" />
     <?endif?>
 
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(AndroidPlatformUpgradeCode)" />
@@ -59,16 +59,16 @@
                   <Directory Name="swift">
                     <Directory Name="android">
                       <?if $(IncludeARM64) = True?>
-                        <Directory Id="XCTest_usr_lib_swift_android_arm64" Name="aarch64" DiskId="2" />
+                        <Directory Id="XCTest_usr_lib_swift_android_arm64" Name="aarch64" DiskId="6" />
                       <?endif?>
                       <?if $(IncludeARM) = True?>
-                        <Directory Id="XCTest_usr_lib_swift_android_arm" Name="armv7" DiskId="3" />
+                        <Directory Id="XCTest_usr_lib_swift_android_arm" Name="armv7" DiskId="7" />
                       <?endif?>
                       <?if $(IncludeX64) = True?>
-                        <Directory Id="XCTest_usr_lib_swift_android_x64" Name="x86_64" DiskId="4" />
+                        <Directory Id="XCTest_usr_lib_swift_android_x64" Name="x86_64" DiskId="8" />
                       <?endif?>
                       <?if $(IncludeX86) = True?>
-                        <Directory Id="XCTest_usr_lib_swift_android_x86" Name="i686" DiskId="5" />
+                        <Directory Id="XCTest_usr_lib_swift_android_x86" Name="i686" DiskId="9" />
                       <?endif?>
                       <Directory Id="XCTest.swiftmodule" Name="XCTest.swiftmodule" />
                     </Directory>
@@ -85,18 +85,18 @@
                     <Directory Name="android">
                       <Directory Id="_Testing_Foundation.swiftmodule" Name="_Testing_Foundation.swiftmodule" />
                       <?if $(IncludeARM64) = True?>
-                        <Directory Id="Testing_usr_lib_swift_android_arm64" Name="aarch64" DiskId="2" />
+                        <Directory Id="Testing_usr_lib_swift_android_arm64" Name="aarch64" DiskId="6" />
                       <?endif?>
                       <?if $(IncludeARM) = True?>
-                        <Directory Id="Testing_usr_lib_swift_android_arm" Name="armv7" DiskId="3" />
+                        <Directory Id="Testing_usr_lib_swift_android_arm" Name="armv7" DiskId="7" />
                       <?endif?>
                       <?if $(IncludeX64) = True?>
-                        <Directory Id="Testing_usr_lib_swift_android_x64" Name="x86_64" DiskId="4" />
+                        <Directory Id="Testing_usr_lib_swift_android_x64" Name="x86_64" DiskId="8" />
                       <?endif?>
                       <?if $(IncludeX86) = True?>
-                        <Directory Id="Testing_usr_lib_swift_android_x86" Name="i686" DiskId="5" />
+                        <Directory Id="Testing_usr_lib_swift_android_x86" Name="i686" DiskId="9" />
                       <?endif?>
-                      <Directory Id="Testing.swiftcrossimport" Name="Testing.swiftcrossimport" />
+                      <Directory Id="Testing.swiftcrossimport" Name="Testing.swiftcrossimport" DiskId="5" />
                       <Directory Id="Testing.swiftmodule" Name="Testing.swiftmodule" />
                     </Directory>
                   </Directory>
@@ -119,54 +119,93 @@
             <Directory Id="AndroidSDK" Name="Android.sdk">
               <Directory Name="usr">
                 <Directory Name="include">
-                  <Directory Id="AndroidSDK_usr_include_Block" Name="Block" />
-                  <Directory Id="AndroidSDK_usr_include_dispatch" Name="dispatch" />
-                  <Directory Id="AndroidSDK_usr_include_os" Name="os" />
-                  <Directory Id="AndroidSDK_usr_include__foundation_unicode" Name="_foundation_unicode" />
-                  <Directory Id="AndroidSDK_usr_include__FoundationCShims" Name="_FoundationCShims" />
+                  <Directory Id="AndroidSDK_usr_include_Block" Name="Block" DiskId="5" />
+                  <Directory Id="AndroidSDK_usr_include_dispatch" Name="dispatch" DiskId="5" />
+                  <Directory Id="AndroidSDK_usr_include_os" Name="os" DiskId="5" />
+                  <Directory Id="AndroidSDK_usr_include__foundation_unicode" Name="_foundation_unicode" DiskId="5" />
+                  <Directory Id="AndroidSDK_usr_include__FoundationCShims" Name="_FoundationCShims" DiskId="5" />
                   <Directory Name="swift">
-                    <Directory Id="AndroidSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror" />
+                    <Directory Id="AndroidSDK_usr_include_swift_SwiftRemoteMirror" Name="SwiftRemoteMirror" DiskId="5" />
                   </Directory>
                 </Directory>
                 <Directory Name="lib">
                   <Directory Name="swift">
-                    <Directory Id="AndroidSDK_usr_lib_swift_apinotes" Name="apinotes" />
-                    <Directory Id="AndroidSDK_usr_lib_swift_shims" Name="shims" />
+                    <Directory Id="AndroidSDK_usr_lib_swift_apinotes" Name="apinotes" DiskId="5" />
+                    <Directory Id="AndroidSDK_usr_lib_swift_shims" Name="shims" DiskId="5" />
                     <Directory Id="AndroidSDK_usr_lib_swift_android" Name="android">
-                      <Directory Id="_Builtin_float.swiftmodule" Name="_Builtin_float.swiftmodule" />
-                      <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule" />
-                      <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule" />
-                      <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule" />
-                      <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule" />
-                      <Directory Id="_Volatile.swiftmodule" Name="_Volatile.swiftmodule" />
                       <Directory Id="Android.swiftmodule" Name="Android.swiftmodule" />
                       <Directory Id="Cxx.swiftmodule" Name="Cxx.swiftmodule" />
                       <Directory Id="CxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
-                      <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule" />
                       <Directory Id="Dispatch.swiftmodule" Name="Dispatch.swiftmodule" />
-                      <Directory Id="_FoundationCollections.swiftmodule" Name="_FoundationCollections.swiftmodule" />
+                      <Directory Id="Distributed.swiftmodule" Name="Distributed.swiftmodule" />
+                      <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
                       <Directory Id="FoundationEssentials.swiftmodule" Name="FoundationEssentials.swiftmodule" />
                       <Directory Id="FoundationInternationalization.swiftmodule" Name="FoundationInternationalization.swiftmodule" />
-                      <Directory Id="Foundation.swiftmodule" Name="Foundation.swiftmodule" />
                       <Directory Id="FoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
                       <Directory Id="FoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
-                      <Directory Id="_math.swiftmodule" Name="_math.swiftmodule" />
                       <Directory Id="Observation.swiftmodule" Name="Observation.swiftmodule" />
                       <Directory Id="RegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
                       <Directory Id="Swift.swiftmodule" Name="Swift.swiftmodule" />
                       <Directory Id="SwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
                       <Directory Id="Synchronization.swiftmodule" Name="Synchronization.swiftmodule" />
+                      <Directory Id="_math.swiftmodule" Name="_math.swiftmodule" />
+                      <Directory Id="_Builtin_float.swiftmodule" Name="_Builtin_float.swiftmodule" />
+                      <Directory Id="_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule" />
+                      <Directory Id="_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule" />
+                      <Directory Id="_FoundationCollections.swiftmodule" Name="_FoundationCollections.swiftmodule" />
+                      <Directory Id="_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule" />
+                      <Directory Id="_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule" />
+                      <Directory Id="_Volatile.swiftmodule" Name="_Volatile.swiftmodule" />
                       <?if $(IncludeARM64) = True?>
-                        <Directory Id="AndroidSDK_usr_lib_swift_android_arm64" Name="aarch64" />
+                        <Directory Id="AndroidSDK_usr_lib_swift_android_arm64" Name="aarch64" DiskId="6" />
                       <?endif?>
                       <?if $(IncludeARM) = True?>
-                        <Directory Id="AndroidSDK_usr_lib_swift_android_arm" Name="armv7" />
+                        <Directory Id="AndroidSDK_usr_lib_swift_android_arm" Name="armv7" DiskId="7" />
                       <?endif?>
                       <?if $(IncludeX64) = True?>
-                        <Directory Id="AndroidSDK_usr_lib_swift_android_x64" Name="x86_64" />
+                        <Directory Id="AndroidSDK_usr_lib_swift_android_x64" Name="x86_64" DiskId="8" />
                       <?endif?>
                       <?if $(IncludeX86) = True?>
-                        <Directory Id="AndroidSDK_usr_lib_swift_android_x86" Name="i686" />
+                        <Directory Id="AndroidSDK_usr_lib_swift_android_x86" Name="i686" DiskId="9" />
+                      <?endif?>
+                    </Directory>
+                  </Directory>
+                  <Directory Name="swift_static">
+                    <Directory Name="android">
+                      <Directory Id="libAndroid.swiftmodule" Name="Android.swiftmodule" />
+                      <Directory Id="libCxx.swiftmodule" Name="Cxx.swiftmodule" />
+                      <Directory Id="libCxxStdlib.swiftmodule" Name="CxxStdlib.swiftmodule" />
+                      <Directory Id="libDispatch.swiftmodule" Name="Dispatch.swiftmodule" />
+                      <Directory Id="libDistributed.swiftmodule" Name="Distributed.swiftmodule" />
+                      <Directory Id="libFoundation.swiftmodule" Name="Foundation.swiftmodule" />
+                      <Directory Id="libFoundationEssentials.swiftmodule" Name="FoundationEssentials.swiftmodule" />
+                      <Directory Id="libFoundationInternationalization.swiftmodule" Name="FoundationInternationalization.swiftmodule" />
+                      <Directory Id="libFoundationNetworking.swiftmodule" Name="FoundationNetworking.swiftmodule" />
+                      <Directory Id="libFoundationXML.swiftmodule" Name="FoundationXML.swiftmodule" />
+                      <Directory Id="libObservation.swiftmodule" Name="Observation.swiftmodule" />
+                      <Directory Id="libRegexBuilder.swiftmodule" Name="RegexBuilder.swiftmodule" />
+                      <Directory Id="libSwift.swiftmodule" Name="Swift.swiftmodule" />
+                      <Directory Id="libSwiftOnoneSupport.swiftmodule" Name="SwiftOnoneSupport.swiftmodule" />
+                      <Directory Id="libSynchronization.swiftmodule" Name="Synchronization.swiftmodule" />
+                      <Directory Id="lib_math.swiftmodule" Name="_math.swiftmodule" />
+                      <Directory Id="lib_Builtin_float.swiftmodule" Name="_Builtin_float.swiftmodule" />
+                      <Directory Id="lib_Concurrency.swiftmodule" Name="_Concurrency.swiftmodule" />
+                      <Directory Id="lib_Differentiation.swiftmodule" Name="_Differentiation.swiftmodule" />
+                      <Directory Id="lib_FoundationCollections.swiftmodule" Name="_FoundationCollections.swiftmodule" />
+                      <Directory Id="lib_RegexParser.swiftmodule" Name="_RegexParser.swiftmodule" />
+                      <Directory Id="lib_StringProcessing.swiftmodule" Name="_StringProcessing.swiftmodule" />
+                      <Directory Id="lib_Volatile.swiftmodule" Name="_Volatile.swiftmodule" />
+                      <?if $(IncludeARM64) = True?>
+                        <Directory Id="AndroidSDK_usr_lib_swift_static_android_arm64" Name="aarch64" DiskId="6" />
+                      <?endif?>
+                      <?if $(IncludeARM) = True?>
+                        <Directory Id="AndroidSDK_usr_lib_swift_static_android_arm" Name="armv7" DiskId="7" />
+                      <?endif?>
+                      <?if $(IncludeX64) = True?>
+                        <Directory Id="AndroidSDK_usr_lib_swift_static_android_x64" Name="x86_64" DiskId="8" />
+                      <?endif?>
+                      <?if $(IncludeX86) = True?>
+                        <Directory Id="AndroidSDK_usr_lib_swift_static_android_x86" Name="i686" DiskId="9" />
                       <?endif?>
                     </Directory>
                   </Directory>
@@ -181,56 +220,56 @@
     <!-- XCTest -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="XCTest.arm64">
-        <Component Directory="XCTest.swiftmodule" DiskId="2">
+        <Component Directory="XCTest.swiftmodule" DiskId="6">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="XCTest.swiftmodule" DiskId="2">
+        <Component Directory="XCTest.swiftmodule" DiskId="6">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="XCTest_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="XCTest_usr_lib_swift_android_arm64">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\aarch64\libXCTest.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="XCTest.arm">
-        <Component Directory="XCTest.swiftmodule" DiskId="3">
+        <Component Directory="XCTest.swiftmodule" DiskId="7">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="XCTest.swiftmodule" DiskId="3">
+        <Component Directory="XCTest.swiftmodule" DiskId="7">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="XCTest.swiftmodule" DiskId="3">
+        <Component Directory="XCTest_usr_lib_swift_android_arm">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\armv7\libXCTest.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="XCTest.x64">
-        <Component Directory="XCTest.swiftmodule" DiskId="4">
+        <Component Directory="XCTest.swiftmodule" DiskId="8">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="XCTest.swiftmodule" DiskId="4">
+        <Component Directory="XCTest.swiftmodule" DiskId="8">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="XCTest_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="XCTest_usr_lib_swift_android_x64">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\x86_64\libXCTest.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="XCTest.x86">
-        <Component Directory="XCTest.swiftmodule" DiskId="5">
+        <Component Directory="XCTest.swiftmodule" DiskId="9">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="XCTest.swiftmodule" DiskId="5">
+        <Component Directory="XCTest.swiftmodule" DiskId="9">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\XCTest.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="XCTest_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="XCTest_usr_lib_swift_android_x86">
           <File Source="$(PlatformRoot)\Developer\Library\XCTest-$(ProductVersion)\usr\lib\swift\android\i686\libXCTest.so" />
         </Component>
       </ComponentGroup>
@@ -242,99 +281,100 @@
         <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftcrossimport\Foundation.swiftoverlay" />
       </Component>
     </ComponentGroup>
+
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Testing.arm64">
-        <Component Directory="Testing.swiftmodule" DiskId="2">
+        <Component Directory="Testing_usr_lib_swift_android_arm64">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\aarch64\libTesting.so" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_android_arm64">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\aarch64\lib_Testing_Foundation.so" />
+        </Component>
+
+        <Component Directory="Testing.swiftmodule" DiskId="6">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="Testing.swiftmodule" DiskId="2">
+        <Component Directory="Testing.swiftmodule" DiskId="6">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
         </Component>
 
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="2">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="6">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="2">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="6">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-
-        <Component Directory="Testing_usr_lib_swift_android_arm64" DiskId="2">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\aarch64\libTesting.so" />
-        </Component>
-        <Component Directory="Testing_usr_lib_swift_android_arm64" DiskId="2">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\aarch64\lib_Testing_Foundation.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Testing.arm">
-        <Component Directory="Testing.swiftmodule" DiskId="3">
+        <Component Directory="Testing_usr_lib_swift_android_arm">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\armv7\libTesting.so" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_android_arm">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\armv7\lib_Testing_Foundation.so" />
+        </Component>
+
+        <Component Directory="Testing.swiftmodule" DiskId="7">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="Testing.swiftmodule" DiskId="3">
+        <Component Directory="Testing.swiftmodule" DiskId="7">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
         </Component>
 
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="3">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="7">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="3">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="7">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-
-        <Component Directory="Testing_usr_lib_swift_android_arm" DiskId="3">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\armv7\libTesting.so" />
-        </Component>
-        <Component Directory="Testing_usr_lib_swift_android_arm" DiskId="3">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\armv7\lib_Testing_Foundation.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Testing.x64">
-        <Component Directory="Testing.swiftmodule" DiskId="4">
+        <Component Directory="Testing_usr_lib_swift_android_x64">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\x86_64\libTesting.so" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_android_x64">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\x86_64\lib_Testing_Foundation.so" />
+        </Component>
+
+        <Component Directory="Testing.swiftmodule" DiskId="8">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="Testing.swiftmodule" DiskId="4">
+        <Component Directory="Testing.swiftmodule" DiskId="8">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
         </Component>
 
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="4">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="8">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="4">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="8">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-
-        <Component Directory="Testing_usr_lib_swift_android_x64" DiskId="4">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\x86_64\libTesting.so" />
-        </Component>
-        <Component Directory="Testing_usr_lib_swift_android_x64" DiskId="4">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\x86_64\lib_Testing_Foundation.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Testing.x86">
-        <Component Directory="Testing.swiftmodule" DiskId="5">
+        <Component Directory="Testing_usr_lib_swift_android_x86">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\i686\libTesting.so" />
+        </Component>
+        <Component Directory="Testing_usr_lib_swift_android_x86">
+          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\i686\lib_Testing_Foundation.so" />
+        </Component>
+
+        <Component Directory="Testing.swiftmodule" DiskId="9">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="Testing.swiftmodule" DiskId="5">
+        <Component Directory="Testing.swiftmodule" DiskId="9">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\Testing.swiftmodule\i686-unknown-linux-android.swiftinterface" />
         </Component>
 
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="5">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="9">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="5">
+        <Component Directory="_Testing_Foundation.swiftmodule" DiskId="9">
           <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\_Testing_Foundation.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-
-        <Component Directory="Testing_usr_lib_swift_android_x86" DiskId="5">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\i686\libTesting.so" />
-        </Component>
-        <Component Directory="Testing_usr_lib_swift_android_x86" DiskId="5">
-          <File Source="$(PlatformRoot)\Developer\Library\Testing-$(ProductVersion)\usr\lib\swift\android\i686\lib_Testing_Foundation.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -342,29 +382,29 @@
     <!-- ds2 -->
     <?if $(ANDROID_INCLUDE_DS2) = True?>
       <?if $(IncludeARM64) = True?>
-        <ComponentGroup Id="ds2.arm64" Directory="_ds2_usr_bin">
-          <Component DiskId="2">
+        <ComponentGroup Id="ds2.arm64">
+          <Component Directory="_ds2_usr_bin" DiskId="6">
             <File Source="$(PlatformRoot)\Developer\Library\ds2\usr\bin\aarch64-unknown-linux-android-ds2" />
           </Component>
         </ComponentGroup>
       <?endif?>
       <?if $(IncludeARM) = True?>
-        <ComponentGroup Id="ds2.arm" Directory="_ds2_usr_bin">
-          <Component DiskId="3">
+        <ComponentGroup Id="ds2.arm">
+          <Component Directory="_ds2_usr_bin" DiskId="7">
             <File Source="$(PlatformRoot)\Developer\Library\ds2\usr\bin\armv7-unknown-linux-android-ds2" />
           </Component>
         </ComponentGroup>
       <?endif?>
       <?if $(IncludeX64) = True?>
-        <ComponentGroup Id="ds2.x64" Directory="_ds2_usr_bin">
-          <Component DiskId="4">
+        <ComponentGroup Id="ds2.x64">
+          <Component Directory="_ds2_usr_bin" DiskId="8">
             <File Source="$(PlatformRoot)\Developer\Library\ds2\usr\bin\x86_64-unknown-linux-android-ds2" />
           </Component>
         </ComponentGroup>
       <?endif?>
       <?if $(IncludeX86) = True?>
-        <ComponentGroup Id="ds2.x86" Directory="_ds2_usr_bin">
-          <Component DiskId="5">
+        <ComponentGroup Id="ds2.x86">
+          <Component Directory="_ds2_usr_bin" DiskId="9">
             <File Source="$(PlatformRoot)\Developer\Library\ds2\usr\bin\i686-unknown-linux-android-ds2" />
           </Component>
         </ComponentGroup>
@@ -391,73 +431,121 @@
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
-      <ComponentGroup Id="SwiftRemoteMirror.arm64" Directory="AndroidSDK_usr_lib_swift_android_arm64">
-        <Component DiskId="2">
+      <ComponentGroup Id="SwiftRemoteMirror.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftRemoteMirror.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftRemoteMirror.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftRemoteMirror.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
-      <ComponentGroup Id="SwiftRemoteMirror.arm" Directory="AndroidSDK_usr_lib_swift_android_arm">
-        <Component DiskId="3">
+      <ComponentGroup Id="SwiftRemoteMirror.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftRemoteMirror.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftRemoteMirror.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftRemoteMirror.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
-      <ComponentGroup Id="SwiftRemoteMirror.x64" Directory="AndroidSDK_usr_lib_swift_android_x64">
-        <Component DiskId="4">
+      <ComponentGroup Id="SwiftRemoteMirror.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftRemoteMirror.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftRemoteMirror.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftRemoteMirror.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
-      <ComponentGroup Id="SwiftRemoteMirror.x86" Directory="AndroidSDK_usr_lib_swift_android_x86">
-        <Component DiskId="5">
+      <ComponentGroup Id="SwiftRemoteMirror.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftRemoteMirror.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftRemoteMirror.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftRemoteMirror.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
 
     <!-- BlocksRuntime -->
-    <ComponentGroup Id="BlocksRuntime">
-      <Component Directory="AndroidSDK_usr_include_Block">
+    <ComponentGroup Id="BlocksRuntime" Directory="AndroidSDK_usr_include_Block">
+      <Component>
         <File Source="$(SDKRoot)\usr\include\Block\Block.h" />
       </Component>
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
-      <ComponentGroup Id="BlocksRuntime.arm64" Directory="AndroidSDK_usr_lib_swift_android_arm64">
-        <Component DiskId="2">
+      <ComponentGroup Id="BlocksRuntime.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libBlocksRuntime.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
-      <ComponentGroup Id="BlocksRuntime.arm" Directory="AndroidSDK_usr_lib_swift_android_arm">
-        <Component DiskId="3">
+      <ComponentGroup Id="BlocksRuntime.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libBlocksRuntime.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
-      <ComponentGroup Id="BlocksRuntime.x64" Directory="AndroidSDK_usr_lib_swift_android_x64">
-        <Component DiskId="4">
+      <ComponentGroup Id="BlocksRuntime.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libBlocksRuntime.so" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
-      <ComponentGroup Id="BlocksRuntime.x86" Directory="AndroidSDK_usr_lib_swift_android_x86">
-        <Component DiskId="5">
+      <ComponentGroup Id="BlocksRuntime.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libBlocksRuntime.so" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="libBlocksRuntime.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libBlocksRuntime.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeARM) = True?>
+      <ComponentGroup Id="libBlocksRuntime.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libBlocksRuntime.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="libBlocksRuntime.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libBlocksRuntime.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="libBlocksRuntime.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libBlocksRuntime.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
 
     <!-- libdispatch -->
-    <ComponentGroup Id="libdispatch" Directory="AndroidSDK_usr_include_dispatch">
-      <?define Disk = 1?>
+    <ComponentGroup Id="Dispatch" Directory="AndroidSDK_usr_include_dispatch">
+      <?define Disk = 5?>
       <?include ../CDispatch.wxi?>
       <?undef Disk?>
 
@@ -476,183 +564,353 @@
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
-      <ComponentGroup Id="libdispatch.arm64">
-        <Component Directory="Dispatch.swiftmodule" DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
-        </Component>
-        <Component Directory="Dispatch.swiftmodule" DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
-        </Component>
-
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+      <ComponentGroup Id="dispatch.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libdispatch.so" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftDispatch.so" />
+      </ComponentGroup>
+      <ComponentGroup Id="libdispatch.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libdispatch.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
-      <ComponentGroup Id="libdispatch.arm">
-        <Component Directory="Dispatch.swiftmodule" DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
-        </Component>
-        <Component Directory="Dispatch.swiftmodule" DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
-        </Component>
-
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+      <ComponentGroup Id="dispatch.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libdispatch.so" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftDispatch.so" />
+      </ComponentGroup>
+      <ComponentGroup Id="libdispatch.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libdispatch.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
-      <ComponentGroup Id="libdispatch.x64">
-        <Component Directory="Dispatch.swiftmodule" DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
-        </Component>
-        <Component Directory="Dispatch.swiftmodule" DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
-        </Component>
-
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+      <ComponentGroup Id="dispatch.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libdispatch.so" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftDispatch.so" />
+      </ComponentGroup>
+      <ComponentGroup Id="libdispatch.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libdispatch.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="dispatch.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libdispatch.so" />
+        </Component>
+      </ComponentGroup>
       <ComponentGroup Id="libdispatch.x86">
-        <Component Directory="Dispatch.swiftmodule" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libdispatch.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="swiftDispatch.arm64" Directory="Dispatch.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftDispatch.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libswiftDispatch.arm64" Directory="libDispatch.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftDispatch.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeARM) = True?>
+      <ComponentGroup Id="swiftDispatch.arm" Directory="Dispatch.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftDispatch.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libswiftDispatch.arm" Directory="libDispatch.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftDispatch.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="swiftDispatch.x64" Directory="Dispatch.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftDispatch.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libswiftDispatch.x64" Directory="libDispatch.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftDispatch.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="swiftDispatch.x86" Directory="Dispatch.swiftmodule">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component Directory="Dispatch.swiftmodule" DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Dispatch.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libdispatch.so" />
-        </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftDispatch.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libswiftDispatch.x86" Directory="libDispatch.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Dispatch.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftDispatch.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
 
     <!-- _FoundationUnicode -->
     <ComponentGroup Id="_FoundationUnicode" Directory="AndroidSDK_usr_include__foundation_unicode">
-      <?define Disk = 1?>
+      <?define Disk = 5?>
       <?include ../_FoundationUnicode.wxi?>
       <?undef Disk?>
     </ComponentGroup>
 
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_FoundationUnicode.arm64">
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\lib_FoundationICU.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationUnicode.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\lib_FoundationICU.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_FoundationUnicode.arm">
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\lib_FoundationICU.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationUnicode.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\lib_FoundationICU.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_FoundationUnicode.x64">
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\lib_FoundationICU.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationUnicode.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\lib_FoundationICU.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_FoundationUnicode.x86">
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\lib_FoundationICU.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationUnicode.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_FoundationICU.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
 
     <!-- _FoundationCShims -->
     <ComponentGroup Id="_FoundationCShims" Directory="AndroidSDK_usr_include__FoundationCShims">
-      <?define Disk = 1?>
+      <?define Disk = 5?>
       <?include ../_FoundationCShims.wxi?>
       <?undef Disk?>
     </ComponentGroup>
 
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.arm64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\lib_FoundationCShims.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeARM) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.arm">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\lib_FoundationCShims.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.x64">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\lib_FoundationCShims.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="lib_FoundationCShims.x86">
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_FoundationCShims.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
     <!-- _Builtin_float -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_Builtin_float.arm64" Directory="_Builtin_float.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_Builtin_float.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Builtin_float.arm64" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_Builtin_float.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_Builtin_float.arm" Directory="_Builtin_float.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_Builtin_float.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Builtin_float.arm" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_Builtin_float.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_Builtin_float.x64" Directory="_Builtin_float.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_Builtin_float.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Builtin_float.x64" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_Builtin_float.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_Builtin_float.x86" Directory="_Builtin_float.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Builtin_float.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_Builtin_float.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Builtin_float.x86" Directory="lib_Builtin_float.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Builtin_float.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_Builtin_float.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -660,69 +918,105 @@
     <!-- _Concurrency -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_Concurrency.arm64" Directory="_Concurrency.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_Concurrency.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Concurrency.arm64" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_Concurrency.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_Concurrency.arm" Directory="_Concurrency.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_Concurrency.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Concurrency.arm" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_Concurrency.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_Concurrency.x64" Directory="_Concurrency.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_Concurrency.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Concurrency.x64" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_Concurrency.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_Concurrency.x86" Directory="_Concurrency.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Concurrency.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_Concurrency.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Concurrency.x86" Directory="lib_Concurrency.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Concurrency.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_Concurrency.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -730,69 +1024,105 @@
     <!-- _Differentiation -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_Differentiation.arm64" Directory="_Differentiation.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_Differentiation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Differentiation.arm64" Directory="lib_Differentiation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_Differentiation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_Differentiation.arm" Directory="_Differentiation.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_Differentiation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Differentiation.arm" Directory="lib_Differentiation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_Differentiation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_Differentiation.x64" Directory="_Differentiation.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_Differentiation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Differentiation.x64" Directory="lib_Differentiation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_Differentiation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_Differentiation.x86" Directory="_Differentiation.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Differentiation.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_Differentiation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Differentiation.x86" Directory="lib_Differentiation.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Differentiation.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_Differentiation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -800,57 +1130,105 @@
     <!-- _RegexParser -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_RegexParser.arm64" Directory="_RegexParser.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_RegexParser.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_RegexParser.arm64" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_RegexParser.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_RegexParser.arm" Directory="_RegexParser.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_RegexParser.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_RegexParser.arm" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_RegexParser.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_RegexParser.x64" Directory="_RegexParser.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_RegexParser.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_RegexParser.x64" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_RegexParser.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_RegexParser.x86" Directory="_RegexParser.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_RegexParser.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_RegexParser.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_RegexParser.x86" Directory="lib_RegexParser.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_RegexParser.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_RegexParser.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -858,69 +1236,105 @@
     <!-- _StringProcessing -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_StringProcessing.arm64" Directory="_StringProcessing.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_StringProcessing.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_StringProcessing.arm64" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_StringProcessing.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_StringProcessing.arm" Directory="_StringProcessing.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_StringProcessing.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_StringProcessing.arm" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_StringProcessing.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_StringProcessing.x64" Directory="_StringProcessing.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_StringProcessing.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_StringProcessing.x64" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_StringProcessing.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_StringProcessing.x86" Directory="_StringProcessing.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_StringProcessing.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_StringProcessing.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_StringProcessing.x86" Directory="lib_StringProcessing.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_StringProcessing.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_StringProcessing.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -928,69 +1342,105 @@
     <!-- _Volatile -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_Volatile.arm64" Directory="_Volatile.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_Volatile.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Volatile.arm64" Directory="lib_Volatile.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_Volatile.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_Volatile.arm" Directory="_Volatile.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_Volatile.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Volatile.arm" Directory="lib_Volatile.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_Volatile.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_Volatile.x64" Directory="_Volatile.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_Volatile.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Volatile.x64" Directory="lib_Volatile.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_Volatile.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_Volatile.x86" Directory="_Volatile.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_Volatile.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_Volatile.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_Volatile.x86" Directory="lib_Volatile.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_Volatile.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_Volatile.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -999,112 +1449,200 @@
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Android.arm64" Directory="Android.swiftmodule">
         <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\android.modulemap" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\SwiftAndroidNDK.h" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\SwiftBionic.h" />
         </Component>
 
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftAndroid.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libAndroid.arm64" Directory="libAndroid.swiftmodule">
+        <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
+        <!--
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\android.modulemap" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\SwiftAndroidNDK.h" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\SwiftBionic.h" />
+        </Component>
+        -->
+
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftAndroid.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Android.arm" Directory="Android.swiftmodule">
         <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\android.modulemap" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\SwiftAndroidNDK.h" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\SwiftBionic.h" />
         </Component>
 
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftAndroid.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libAndroid.arm" Directory="libAndroid.swiftmodule">
+        <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
+        <!--
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\android.modulemap" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\SwiftAndroidNDK.h" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\SwiftBionic.h" />
+        </Component>
+        -->
+
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftAndroid.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Android.x64" Directory="Android.swiftmodule">
         <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\android.modulemap" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\SwiftAndroidNDK.h" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\SwiftBionic.h" />
         </Component>
 
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftAndroid.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libAndroid.x64" Directory="libAndroid.swiftmodule">
+        <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
+        <!--
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\android.modulemap" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\SwiftAndroidNDK.h" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\SwiftBionic.h" />
+        </Component>
+        -->
+
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftAndroid.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Android.x86" Directory="Android.swiftmodule">
         <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\android.modulemap" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\SwiftAndroidNDK.h" />
         </Component>
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\SwiftBionic.h" />
         </Component>
 
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Android.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftAndroid.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libAndroid.x86" Directory="libAndroid.swiftmodule">
+        <!-- FIXME(swiftlang/swift#80293) - these should be architecture agnostic -->
+        <!--
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\android.modulemap" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\SwiftAndroidNDK.h" />
+        </Component>
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\SwiftBionic.h" />
+        </Component>
+        -->
+
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Android.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftAndroid.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1112,57 +1650,105 @@
     <!-- Cxx -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Cxx.arm64" Directory="Cxx.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftCxx.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxx.arm64" Directory="libCxx.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftCxx.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Cxx.arm" Directory="Cxx.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftCxx.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxx.arm" Directory="libCxx.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftCxx.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Cxx.x64" Directory="Cxx.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftCxx.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxx.x64" Directory="libCxx.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftCxx.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Cxx.x86" Directory="Cxx.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Cxx.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftCxx.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxx.x86" Directory="libCxx.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Cxx.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftCxx.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1170,57 +1756,105 @@
     <!-- CxxStdlib -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="CxxStdlib.arm64" Directory="CxxStdlib.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftCxxStdlib.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxxStdlib.arm64" Directory="libCxxStdlib.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftCxxStdlib.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="CxxStdlib.arm" Directory="CxxStdlib.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftCxxStdlib.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxxStdlib.arm" Directory="libCxxStdlib.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftCxxStdlib.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="CxxStdlib.x64" Directory="CxxStdlib.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftCxxStdlib.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxxStdlib.x64" Directory="libCxxStdlib.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftCxxStdlib.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="CxxStdlib.x86" Directory="CxxStdlib.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\CxxStdlib.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftCxxStdlib.a" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libCxxStdlib.x86" Directory="libCxxStdlib.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\CxxStdlib.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftCxxStdlib.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1228,69 +1862,105 @@
     <!-- Distributed -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Distributed.arm64" Directory="Distributed.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftDistributed.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libDistributed.arm64" Directory="libDistributed.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftDistributed.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Distributed.arm" Directory="Distributed.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftDistributed.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libDistributed.arm" Directory="libDistributed.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftDistributed.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Distributed.x64" Directory="Distributed.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftDistributed.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libDistributed.x64" Directory="libDistributed.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftDistributed.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Distributed.x86" Directory="Distributed.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Distributed.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftDistributed.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libDistributed.x86" Directory="libDistributed.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Distributed.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftDistributed.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1298,41 +1968,89 @@
     <!-- _FoundationCollections -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_FoundationCollections.arm64" Directory="_FoundationCollections.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationCollections.arm64" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\lib_FoundationCollections.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_FoundationCollections.arm" Directory="_FoundationCollections.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationCollections.arm" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\lib_FoundationCollections.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_FoundationCollections.x64" Directory="_FoundationCollections.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationCollections.x64" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\lib_FoundationCollections.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_FoundationCollections.x86" Directory="_FoundationCollections.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_FoundationCollections.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_FoundationCollections.x86" Directory="lib_FoundationCollections.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_FoundationCollections.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_FoundationCollections.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1340,57 +2058,105 @@
     <!-- FoundationEssentials -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="FoundationEssentials.arm64" Directory="FoundationEssentials.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libFoundationEssentials.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationEssentials.arm64" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libFoundationEssentials.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="FoundationEssentials.arm" Directory="FoundationEssentials.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libFoundationEssentials.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationEssentials.arm" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libFoundationEssentials.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="FoundationEssentials.x64" Directory="FoundationEssentials.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libFoundationEssentials.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationEssentials.x64" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libFoundationEssentials.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="FoundationEssentials.x86" Directory="FoundationEssentials.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationEssentials.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libFoundationEssentials.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationEssentials.x86" Directory="libFoundationEssentials.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationEssentials.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libFoundationEssentials.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1398,57 +2164,105 @@
     <!-- FoundationInternationalization -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="FoundationInternationalization.arm64" Directory="FoundationInternationalization.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libFoundationInternationalization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationInternationalization.arm64" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libFoundationInternationalization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="FoundationInternationalization.arm" Directory="FoundationInternationalization.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libFoundationInternationalization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationInternationalization.arm" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libFoundationInternationalization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="FoundationInternationalization.x64" Directory="FoundationInternationalization.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libFoundationInternationalization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationInternationalization.x64" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libFoundationInternationalization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="FoundationInternationalization.x86" Directory="FoundationInternationalization.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationInternationalization.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libFoundationInternationalization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationInternationalization.x86" Directory="libFoundationInternationalization.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationInternationalization.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libFoundationInternationalization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1456,57 +2270,105 @@
     <!-- Foundation -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Foundation.arm64" Directory="Foundation.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libFoundation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundation.arm64" Directory="libFoundation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libFoundation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Foundation.arm" Directory="Foundation.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libFoundation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundation.arm" Directory="libFoundation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libFoundation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Foundation.x64" Directory="Foundation.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libFoundation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundation.x64" Directory="libFoundation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libFoundation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Foundation.x86" Directory="Foundation.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Foundation.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libFoundation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundation.x86" Directory="libFoundation.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Foundation.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libFoundation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1514,57 +2376,105 @@
     <!-- FoundationNetworking -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="FoundationNetworking.arm64" Directory="FoundationNetworking.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libFoundationNetworking.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationNetworking.arm64" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libFoundationNetworking.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="FoundationNetworking.arm" Directory="FoundationNetworking.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libFoundationNetworking.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationNetworking.arm" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libFoundationNetworking.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="FoundationNetworking.x64" Directory="FoundationNetworking.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libFoundationNetworking.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationNetworking.x64" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libFoundationNetworking.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="FoundationNetworking.x86" Directory="FoundationNetworking.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationNetworking.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libFoundationNetworking.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationNetworking.x86" Directory="libFoundationNetworking.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationNetworking.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libFoundationNetworking.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1572,57 +2482,105 @@
     <!-- FoundationXML -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="FoundationXML.arm64" Directory="FoundationXML.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libFoundationXML.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationXML.arm64" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libFoundationXML.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="FoundationXML.arm" Directory="FoundationXML.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libFoundationXML.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationXML.arm" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libFoundationXML.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="FoundationXML.x64" Directory="FoundationXML.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libFoundationXML.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationXML.x64" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libFoundationXML.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="FoundationXML.x86" Directory="FoundationXML.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\FoundationXML.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libFoundationXML.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libFoundationXML.x86" Directory="libFoundationXML.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\FoundationXML.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libFoundationXML.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1630,69 +2588,183 @@
     <!-- _math -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="_math.arm64" Directory="_math.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswift_math.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_math.arm64" Directory="lib_math.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswift_math.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="_math.arm" Directory="_math.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswift_math.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_math.arm" Directory="lib_math.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswift_math.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="_math.x64" Directory="_math.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswift_math.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_math.x64" Directory="lib_math.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswift_math.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="_math.x86" Directory="_math.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\_math.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswift_math.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="lib_math.x86" Directory="lib_math.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\_math.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswift_math.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+
+    <!-- Foundation Dependencies -->
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="FoundationDependencies.arm64" Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libbrotlicommon.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libbrotlidec.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libcurl.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libxml2.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libz.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeARM) = True?>
+      <ComponentGroup Id="FoundationDependencies.arm" Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libbrotlicommon.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libbrotlidec.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libcurl.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libxml2.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libz.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="FoundationDependencies.x64" Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libbrotlicommon.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libbrotlidec.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libcurl.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libxml2.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libz.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="FoundationDependencies.x86" Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libbrotlicommon.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libbrotlidec.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libcurl.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libxml2.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libz.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1700,69 +2772,105 @@
     <!-- Observation -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Observation.arm64" Directory="Observation.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftObservation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libObservation.arm64" Directory="libObservation.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftObservation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Observation.arm" Directory="Observation.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftObservation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libObservation.arm" Directory="libObservation.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftObservation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Observation.x64" Directory="Observation.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftObservation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libObservation.x64" Directory="libObservation.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftObservation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Observation.x86" Directory="Observation.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Observation.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftObservation.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libObservation.x86" Directory="libObservation.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Observation.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftObservation.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1770,69 +2878,105 @@
     <!-- RegexBuilder -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="RegexBuilder.arm64" Directory="RegexBuilder.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftRegexBuilder.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libRegexBuilder.arm64" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftRegexBuilder.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="RegexBuilder.arm" Directory="RegexBuilder.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftRegexBuilder.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libRegexBuilder.arm" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftRegexBuilder.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="RegexBuilder.x64" Directory="RegexBuilder.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftRegexBuilder.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libRegexBuilder.x64" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftRegexBuilder.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="RegexBuilder.x86" Directory="RegexBuilder.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\RegexBuilder.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftRegexBuilder.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libRegexBuilder.x86" Directory="libRegexBuilder.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\RegexBuilder.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftRegexBuilder.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1840,69 +2984,105 @@
     <!-- Swift -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Swift.arm64" Directory="Swift.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftCore.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwift.arm64" Directory="libSwift.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftCore.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Swift.arm" Directory="Swift.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftCore.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwift.arm" Directory="libSwift.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftCore.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Swift.x64" Directory="Swift.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftCore.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwift.x64" Directory="libSwift.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftCore.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Swift.x86" Directory="Swift.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Swift.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftCore.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwift.x86" Directory="libSwift.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Swift.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftCore.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1910,69 +3090,105 @@
     <!-- SwiftOnoneSupport -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="SwiftOnoneSupport.arm64" Directory="SwiftOnoneSupport.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftSwiftOnoneSupport.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftOnoneSupport.arm64" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftSwiftOnoneSupport.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="SwiftOnoneSupport.arm" Directory="SwiftOnoneSupport.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftSwiftOnoneSupport.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftOnoneSupport.arm" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftSwiftOnoneSupport.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="SwiftOnoneSupport.x64" Directory="SwiftOnoneSupport.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftSwiftOnoneSupport.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftOnoneSupport.x64" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftSwiftOnoneSupport.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="SwiftOnoneSupport.x86" Directory="SwiftOnoneSupport.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\SwiftOnoneSupport.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="5">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftSwiftOnoneSupport.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSwiftOnoneSupport.x86" Directory="libSwiftOnoneSupport.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\SwiftOnoneSupport.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftSwiftOnoneSupport.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
@@ -1980,74 +3196,111 @@
     <!-- Synchronization -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Synchronization.arm64" Directory="Synchronization.swiftmodule">
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="2">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\aarch64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="2">
+        <Component DiskId="6">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\libswiftSynchronization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSynchronization.arm64" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\aarch64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="6">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\aarch64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libswiftSynchronization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Synchronization.arm" Directory="Synchronization.swiftmodule">
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="3">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\armv7-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="3">
+        <Component DiskId="7">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_arm" DiskId="3">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_arm">
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\libswiftSynchronization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSynchronization.arm" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\armv7-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="7">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\armv7-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_arm">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libswiftSynchronization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Synchronization.x64" Directory="Synchronization.swiftmodule">
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="4">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\x86_64-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="4">
+        <Component DiskId="8">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x64" DiskId="4">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x64">
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\libswiftSynchronization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSynchronization.x64" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\x86_64-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="8">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\x86_64-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x64">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libswiftSynchronization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Synchronization.x86" Directory="Synchronization.swiftmodule">
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\i686-unknown-linux-android.swiftdoc" />
         </Component>
-        <Component DiskId="5">
-          <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\i686-unknown-linux-android.swiftinterface" />
-        </Component>
-        <Component DiskId="5">
+        <Component DiskId="9">
           <File Source="$(SDKRoot)\usr\lib\swift\android\Synchronization.swiftmodule\i686-unknown-linux-android.swiftmodule" />
         </Component>
 
-        <Component Directory="AndroidSDK_usr_lib_swift_android_x86" DiskId="2">
+        <Component Directory="AndroidSDK_usr_lib_swift_android_x86">
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\libswiftSynchronization.so" />
+        </Component>
+      </ComponentGroup>
+      <ComponentGroup Id="libSynchronization.x86" Directory="libSynchronization.swiftmodule">
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\i686-unknown-linux-android.swiftdoc" />
+        </Component>
+        <Component DiskId="9">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\Synchronization.swiftmodule\i686-unknown-linux-android.swiftmodule" />
+        </Component>
+
+        <Component Directory="AndroidSDK_usr_lib_swift_static_android_x86">
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libswiftSynchronization.a" />
         </Component>
       </ComponentGroup>
     <?endif?>
 
-    <ComponentGroup Id="apinotes" Directory="AndroidSDK_usr_lib_swift_apinotes">
+    <!-- apinotes -->
+    <ComponentGroup Id="APINotes" Directory="AndroidSDK_usr_lib_swift_apinotes">
       <Component>
         <File Source="$(SDKRoot)\usr\lib\swift\apinotes\std.apinotes" />
       </Component>
@@ -2056,14 +3309,15 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="libcxxshim" Directory="AndroidSDK_usr_lib_swift_android">
-      <Component>
+    <!-- libcxxshim -->
+    <ComponentGroup Id="CXXShim" Directory="AndroidSDK_usr_lib_swift_android">
+      <Component DiskId="5">
         <File Source="$(SDKRoot)\usr\lib\swift\android\libcxxshim.h" />
       </Component>
-      <Component>
+      <Component DiskId="5">
         <File Source="$(SDKRoot)\usr\lib\swift\android\libcxxshim.modulemap" />
       </Component>
-      <Component>
+      <Component DiskId="5">
         <File Source="$(SDKRoot)\usr\lib\swift\android\libcxxstdlibshim.h" />
       </Component>
     </ComponentGroup>
@@ -2071,78 +3325,173 @@
     <!-- Registrar -->
     <?if $(IncludeARM64) = True?>
       <ComponentGroup Id="Registrar.arm64" Directory="AndroidSDK_usr_lib_swift_android_arm64">
-        <Component DiskId="2">
+        <Component>
           <File Source="$(SDKRoot)\usr\lib\swift\android\aarch64\swiftrt.o" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeARM) = True?>
       <ComponentGroup Id="Registrar.arm" Directory="AndroidSDK_usr_lib_swift_android_arm">
-        <Component DiskId="3">
+        <Component>
           <File Source="$(SDKRoot)\usr\lib\swift\android\armv7\swiftrt.o" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX64) = True?>
       <ComponentGroup Id="Registrar.x64" Directory="AndroidSDK_usr_lib_swift_android_x64">
-        <Component DiskId="4">
+        <Component>
           <File Source="$(SDKRoot)\usr\lib\swift\android\x86_64\swiftrt.o" />
         </Component>
       </ComponentGroup>
     <?endif?>
     <?if $(IncludeX86) = True?>
       <ComponentGroup Id="Registrar.x86" Directory="AndroidSDK_usr_lib_swift_android_x86">
-        <Component DiskId="5">
+        <Component>
           <File Source="$(SDKRoot)\usr\lib\swift\android\i686\swiftrt.o" />
         </Component>
       </ComponentGroup>
     <?endif?>
 
     <ComponentGroup Id="Configuration">
-      <Component Directory="AndroidSDK">
+      <Component Directory="AndroidSDK" DiskId="5">
         <File Source="$(SDKRoot)\SDKSettings.json" />
       </Component>
-      <Component Directory="AndroidSDK">
+      <Component Directory="AndroidSDK" DiskId="5">
         <File Source="$(SDKRoot)\SDKSettings.plist" />
       </Component>
-      <Component Directory="AndroidPlatform">
+      <Component Directory="AndroidPlatform" DiskId="5">
         <File Source="$(PlatformRoot)\Info.plist" />
       </Component>
     </ComponentGroup>
 
-    <!-- Features -->
-    <Feature Id="SDK" AllowAbsent="no" Title="!(loc.Plt_ProductName_Android)">
-      <ComponentGroupRef Id="SwiftRemoteMirror" />
-      <ComponentGroupRef Id="BlocksRuntime" />
-      <ComponentGroupRef Id="libdispatch" />
-      <ComponentGroupRef Id="_FoundationUnicode" />
-      <ComponentGroupRef Id="_FoundationCShims" />
+    <!-- CoreFoundation -->
+    <?if $(IncludeARM64) = True?>
+      <ComponentGroup Id="CoreFoundation.arm64" Directory="AndroidSDK_usr_lib_swift_android_arm64">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\libCoreFoundation.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\lib_CFURLSessionInterface.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\lib_CFXMLInterface.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeARM) = True?>
+      <ComponentGroup Id="CoreFoundation.arm" Directory="AndroidSDK_usr_lib_swift_android_arm">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\libCoreFoundation.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\lib_CFURLSessionInterface.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\lib_CFXMLInterface.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX64) = True?>
+      <ComponentGroup Id="CoreFoundation.x64" Directory="AndroidSDK_usr_lib_swift_android_x64">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\libCoreFoundation.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\lib_CFURLSessionInterface.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\lib_CFXMLInterface.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
+    <?if $(IncludeX86) = True?>
+      <ComponentGroup Id="CoreFoundation.x86" Directory="AndroidSDK_usr_lib_swift_android_x86">
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\libCoreFoundation.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_CFURLSessionInterface.a" />
+        </Component>
+        <Component>
+          <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_CFXMLInterface.a" />
+        </Component>
+      </ComponentGroup>
+    <?endif?>
 
+    <!-- Features -->
+    <Feature Display="hidden" Id="PlatformSupport" Title="!(loc.Plt_ProductName_Android)">
       <ComponentGroupRef Id="Testing" />
 
-      <ComponentGroupRef Id="Configuration" />
-      <ComponentGroupRef Id="SwiftShims" />
-      <ComponentGroupRef Id="apinotes" />
-      <ComponentGroupRef Id="libcxxshim" />
-
+      <!-- MSI management Components -->
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
 
     <?if $(IncludeARM64) = True?>
-      <Feature Id="arm64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_arm64)">
-        <Level Condition="INSTALLARM64SDK = 0" Value="0" />
+      <Feature Id="arm64.platform" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Android_arm64)">
+        <Level Condition="INSTALLARM64PLATFORM = 0" Value="0" />
 
         <ComponentGroupRef Id="XCTest.arm64" />
         <ComponentGroupRef Id="Testing.arm64" />
+        <?if $(ANDROID_INCLUDE_DS2) = True?>
+          <ComponentGroupRef Id="ds2.arm64" />
+        <?endif?>
+      </Feature>
+    <?endif?>
 
-        <ComponentGroupRef Id="SwiftRemoteMirror.arm64" />
+    <?if $(IncludeARM) = True?>
+      <Feature Id="armv7.platform" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Android_armv7)">
+        <Level Condition="INSTALLARMV7PLATFORM = 0" Value="0" />
 
-        <ComponentGroupRef Id="BlocksRuntime.arm64" />
-        <ComponentGroupRef Id="libdispatch.arm64" />
+        <ComponentGroupRef Id="XCTest.arm" />
+        <ComponentGroupRef Id="Testing.arm" />
+        <?if $(ANDROID_INCLUDE_DS2) = True?>
+          <ComponentGroupRef Id="ds2.arm" />
+        <?endif?>
+      </Feature>
+    <?endif?>
 
-        <ComponentGroupRef Id="_math.arm64" />
+    <?if $(IncludeX64) = True?>
+      <Feature Id="x64.platform" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Android_amd64)">
+        <Level Condition="INSTALLX64PLATFORM = 0" Value="0" />
+
+        <ComponentGroupRef Id="XCTest.x64" />
+        <ComponentGroupRef Id="Testing.x64" />
+        <?if $(ANDROID_INCLUDE_DS2) = True?>
+          <ComponentGroupRef Id="ds2.x64" />
+        <?endif?>
+      </Feature>
+    <?endif?>
+
+    <?if $(IncludeX86) = True?>
+      <Feature Id="x86.platform" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Android_x86)">
+        <Level Condition="INSTALLX86PLATFORM = 0" Value="0" />
+
+        <ComponentGroupRef Id="XCTest.x86" />
+        <ComponentGroupRef Id="Testing.x86" />
+        <?if $(ANDROID_INCLUDE_DS2) = True?>
+          <ComponentGroupRef Id="ds2.x86" />
+        <?endif?>
+      </Feature>
+    <?endif?>
+
+    <Feature Id="SDK" AllowAbsent="yes" Title="!(loc.Plt_ProductName_Android)">
+      <ComponentGroupRef Id="APINotes" />
+      <ComponentGroupRef Id="BlocksRuntime" />
+      <ComponentGroupRef Id="CXXShim" />
+      <ComponentGroupRef Id="Configuration" />
+      <ComponentGroupRef Id="Dispatch" />
+      <ComponentGroupRef Id="SwiftRemoteMirror" />
+      <ComponentGroupRef Id="SwiftShims" />
+      <ComponentGroupRef Id="_FoundationCShims" />
+      <ComponentGroupRef Id="_FoundationUnicode" />
+    </Feature>
+
+    <?if $(IncludeARM64) = True?>
+      <Feature Id="ARM64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_arm64)">
+        <Level Condition="INSTALLARM64SDK = 0" Value="0" />
+
         <ComponentGroupRef Id="Android.arm64" />
-
+        <ComponentGroupRef Id="BlocksRuntime.arm64" />
         <ComponentGroupRef Id="Cxx.arm64" />
         <ComponentGroupRef Id="CxxStdlib.arm64" />
         <ComponentGroupRef Id="Distributed.arm64" />
@@ -2155,7 +3504,9 @@
         <ComponentGroupRef Id="RegexBuilder.arm64" />
         <ComponentGroupRef Id="Swift.arm64" />
         <ComponentGroupRef Id="SwiftOnoneSupport.arm64" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.arm64" />
         <ComponentGroupRef Id="Synchronization.arm64" />
+        <ComponentGroupRef Id="_math.arm64" />
         <ComponentGroupRef Id="_Builtin_float.arm64" />
         <ComponentGroupRef Id="_Concurrency.arm64" />
         <ComponentGroupRef Id="_Differentiation.arm64" />
@@ -2164,12 +3515,41 @@
         <ComponentGroupRef Id="_RegexParser.arm64" />
         <ComponentGroupRef Id="_StringProcessing.arm64" />
         <ComponentGroupRef Id="_Volatile.arm64" />
+        <ComponentGroupRef Id="dispatch.arm64" />
+        <ComponentGroupRef Id="swiftDispatch.arm64" />
+
+        <ComponentGroupRef Id="CoreFoundation.arm64" />
+        <ComponentGroupRef Id="FoundationDependencies.arm64" />
+        <ComponentGroupRef Id="libAndroid.arm64" />
+        <ComponentGroupRef Id="libBlocksRuntime.arm64" />
+        <ComponentGroupRef Id="libCxx.arm64" />
+        <ComponentGroupRef Id="libCxxStdlib.arm64" />
+        <ComponentGroupRef Id="libDistributed.arm64" />
+        <ComponentGroupRef Id="libFoundation.arm64" />
+        <ComponentGroupRef Id="libFoundationEssentials.arm64" />
+        <ComponentGroupRef Id="libFoundationInternationalization.arm64" />
+        <ComponentGroupRef Id="libFoundationNetworking.arm64" />
+        <ComponentGroupRef Id="libFoundationXML.arm64" />
+        <ComponentGroupRef Id="libObservation.arm64" />
+        <ComponentGroupRef Id="libRegexBuilder.arm64" />
+        <ComponentGroupRef Id="libSwift.arm64" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.arm64" />
+        <ComponentGroupRef Id="libSwiftRemoteMirror.arm64" />
+        <ComponentGroupRef Id="libSynchronization.arm64" />
+        <ComponentGroupRef Id="lib_math.arm64" />
+        <ComponentGroupRef Id="lib_Builtin_float.arm64" />
+        <ComponentGroupRef Id="lib_Concurrency.arm64" />
+        <ComponentGroupRef Id="lib_Differentiation.arm64" />
+        <ComponentGroupRef Id="lib_FoundationCShims.arm64" />
+        <ComponentGroupRef Id="lib_FoundationCollections.arm64" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.arm64" />
+        <ComponentGroupRef Id="lib_RegexParser.arm64" />
+        <ComponentGroupRef Id="lib_StringProcessing.arm64" />
+        <ComponentGroupRef Id="lib_Volatile.arm64" />
+        <ComponentGroupRef Id="libdispatch.arm64" />
+        <ComponentGroupRef Id="libswiftDispatch.arm64" />
 
         <ComponentGroupRef Id="Registrar.arm64" />
-
-        <?if $(ANDROID_INCLUDE_DS2) = True?>
-          <ComponentGroupRef Id="ds2.arm64" />
-        <?endif?>
       </Feature>
     <?endif?>
 
@@ -2177,17 +3557,8 @@
       <Feature Id="armv7" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_armv7)">
         <Level Condition="INSTALLARMSDK = 0" Value="0" />
 
-        <ComponentGroupRef Id="XCTest.arm" />
-        <ComponentGroupRef Id="Testing.arm" />
-
-        <ComponentGroupRef Id="SwiftRemoteMirror.arm" />
-
-        <ComponentGroupRef Id="BlocksRuntime.arm" />
-        <ComponentGroupRef Id="libdispatch.arm" />
-
-        <ComponentGroupRef Id="_math.arm" />
         <ComponentGroupRef Id="Android.arm" />
-
+        <ComponentGroupRef Id="BlocksRuntime.arm" />
         <ComponentGroupRef Id="Cxx.arm" />
         <ComponentGroupRef Id="CxxStdlib.arm" />
         <ComponentGroupRef Id="Distributed.arm" />
@@ -2200,7 +3571,9 @@
         <ComponentGroupRef Id="RegexBuilder.arm" />
         <ComponentGroupRef Id="Swift.arm" />
         <ComponentGroupRef Id="SwiftOnoneSupport.arm" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.arm" />
         <ComponentGroupRef Id="Synchronization.arm" />
+        <ComponentGroupRef Id="_math.arm" />
         <ComponentGroupRef Id="_Builtin_float.arm" />
         <ComponentGroupRef Id="_Concurrency.arm" />
         <ComponentGroupRef Id="_Differentiation.arm" />
@@ -2209,12 +3582,41 @@
         <ComponentGroupRef Id="_RegexParser.arm" />
         <ComponentGroupRef Id="_StringProcessing.arm" />
         <ComponentGroupRef Id="_Volatile.arm" />
+        <ComponentGroupRef Id="dispatch.arm" />
+        <ComponentGroupRef Id="swiftDispatch.arm" />
+
+        <ComponentGroupRef Id="CoreFoundation.arm" />
+        <ComponentGroupRef Id="FoundationDependencies.arm" />
+        <ComponentGroupRef Id="libAndroid.arm" />
+        <ComponentGroupRef Id="libBlocksRuntime.arm" />
+        <ComponentGroupRef Id="libCxx.arm" />
+        <ComponentGroupRef Id="libCxxStdlib.arm" />
+        <ComponentGroupRef Id="libDistributed.arm" />
+        <ComponentGroupRef Id="libFoundation.arm" />
+        <ComponentGroupRef Id="libFoundationEssentials.arm" />
+        <ComponentGroupRef Id="libFoundationInternationalization.arm" />
+        <ComponentGroupRef Id="libFoundationNetworking.arm" />
+        <ComponentGroupRef Id="libFoundationXML.arm" />
+        <ComponentGroupRef Id="libObservation.arm" />
+        <ComponentGroupRef Id="libRegexBuilder.arm" />
+        <ComponentGroupRef Id="libSwift.arm" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.arm" />
+        <ComponentGroupRef Id="libSwiftRemoteMirror.arm" />
+        <ComponentGroupRef Id="libSynchronization.arm" />
+        <ComponentGroupRef Id="lib_math.arm" />
+        <ComponentGroupRef Id="lib_Builtin_float.arm" />
+        <ComponentGroupRef Id="lib_Concurrency.arm" />
+        <ComponentGroupRef Id="lib_Differentiation.arm" />
+        <ComponentGroupRef Id="lib_FoundationCShims.arm" />
+        <ComponentGroupRef Id="lib_FoundationCollections.arm" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.arm" />
+        <ComponentGroupRef Id="lib_RegexParser.arm" />
+        <ComponentGroupRef Id="lib_StringProcessing.arm" />
+        <ComponentGroupRef Id="lib_Volatile.arm" />
+        <ComponentGroupRef Id="libdispatch.arm" />
+        <ComponentGroupRef Id="libswiftDispatch.arm" />
 
         <ComponentGroupRef Id="Registrar.arm" />
-
-        <?if $(ANDROID_INCLUDE_DS2) = True?>
-          <ComponentGroupRef Id="ds2.arm" />
-        <?endif?>
       </Feature>
     <?endif?>
 
@@ -2222,17 +3624,8 @@
       <Feature Id="amd64" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_amd64)">
         <Level Condition="INSTALLAMD64SDK = 0" Value="0" />
 
-        <ComponentGroupRef Id="XCTest.x64" />
-        <ComponentGroupRef Id="Testing.x64" />
-
-        <ComponentGroupRef Id="SwiftRemoteMirror.x64" />
-
-        <ComponentGroupRef Id="BlocksRuntime.x64" />
-        <ComponentGroupRef Id="libdispatch.x64" />
-
-        <ComponentGroupRef Id="_math.x64" />
         <ComponentGroupRef Id="Android.x64" />
-
+        <ComponentGroupRef Id="BlocksRuntime.x64" />
         <ComponentGroupRef Id="Cxx.x64" />
         <ComponentGroupRef Id="CxxStdlib.x64" />
         <ComponentGroupRef Id="Distributed.x64" />
@@ -2245,7 +3638,9 @@
         <ComponentGroupRef Id="RegexBuilder.x64" />
         <ComponentGroupRef Id="Swift.x64" />
         <ComponentGroupRef Id="SwiftOnoneSupport.x64" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.x64" />
         <ComponentGroupRef Id="Synchronization.x64" />
+        <ComponentGroupRef Id="_math.x64" />
         <ComponentGroupRef Id="_Builtin_float.x64" />
         <ComponentGroupRef Id="_Concurrency.x64" />
         <ComponentGroupRef Id="_Differentiation.x64" />
@@ -2254,12 +3649,41 @@
         <ComponentGroupRef Id="_RegexParser.x64" />
         <ComponentGroupRef Id="_StringProcessing.x64" />
         <ComponentGroupRef Id="_Volatile.x64" />
+        <ComponentGroupRef Id="dispatch.x64" />
+        <ComponentGroupRef Id="swiftDispatch.x64" />
+
+        <ComponentGroupRef Id="CoreFoundation.x64" />
+        <ComponentGroupRef Id="FoundationDependencies.x64" />
+        <ComponentGroupRef Id="libAndroid.x64" />
+        <ComponentGroupRef Id="libBlocksRuntime.x64" />
+        <ComponentGroupRef Id="libCxx.x64" />
+        <ComponentGroupRef Id="libCxxStdlib.x64" />
+        <ComponentGroupRef Id="libDistributed.x64" />
+        <ComponentGroupRef Id="libFoundation.x64" />
+        <ComponentGroupRef Id="libFoundationEssentials.x64" />
+        <ComponentGroupRef Id="libFoundationInternationalization.x64" />
+        <ComponentGroupRef Id="libFoundationNetworking.x64" />
+        <ComponentGroupRef Id="libFoundationXML.x64" />
+        <ComponentGroupRef Id="libObservation.x64" />
+        <ComponentGroupRef Id="libRegexBuilder.x64" />
+        <ComponentGroupRef Id="libSwift.x64" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.x64" />
+        <ComponentGroupRef Id="libSwiftRemoteMirror.x64" />
+        <ComponentGroupRef Id="libSynchronization.x64" />
+        <ComponentGroupRef Id="lib_math.x64" />
+        <ComponentGroupRef Id="lib_Builtin_float.x64" />
+        <ComponentGroupRef Id="lib_Concurrency.x64" />
+        <ComponentGroupRef Id="lib_Differentiation.x64" />
+        <ComponentGroupRef Id="lib_FoundationCShims.x64" />
+        <ComponentGroupRef Id="lib_FoundationCollections.x64" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.x64" />
+        <ComponentGroupRef Id="lib_RegexParser.x64" />
+        <ComponentGroupRef Id="lib_StringProcessing.x64" />
+        <ComponentGroupRef Id="lib_Volatile.x64" />
+        <ComponentGroupRef Id="libdispatch.x64" />
+        <ComponentGroupRef Id="libswiftDispatch.x64" />
 
         <ComponentGroupRef Id="Registrar.x64" />
-
-        <?if $(ANDROID_INCLUDE_DS2) = True?>
-          <ComponentGroupRef Id="ds2.x64" />
-        <?endif?>
       </Feature>
     <?endif?>
 
@@ -2267,17 +3691,8 @@
       <Feature Id="x86" AllowAbsent="yes" Title="!(loc.Sdk_ProductName_Android_x86)">
         <Level Condition="INSTALLX86SDK = 0" Value="0" />
 
-        <ComponentGroupRef Id="XCTest.x86" />
-        <ComponentGroupRef Id="Testing.x86" />
-
-        <ComponentGroupRef Id="SwiftRemoteMirror.x86" />
-
-        <ComponentGroupRef Id="BlocksRuntime.x86" />
-        <ComponentGroupRef Id="libdispatch.x86" />
-
-        <ComponentGroupRef Id="_math.x86" />
         <ComponentGroupRef Id="Android.x86" />
-
+        <ComponentGroupRef Id="BlocksRuntime.x86" />
         <ComponentGroupRef Id="Cxx.x86" />
         <ComponentGroupRef Id="CxxStdlib.x86" />
         <ComponentGroupRef Id="Distributed.x86" />
@@ -2290,7 +3705,9 @@
         <ComponentGroupRef Id="RegexBuilder.x86" />
         <ComponentGroupRef Id="Swift.x86" />
         <ComponentGroupRef Id="SwiftOnoneSupport.x86" />
+        <ComponentGroupRef Id="SwiftRemoteMirror.x86" />
         <ComponentGroupRef Id="Synchronization.x86" />
+        <ComponentGroupRef Id="_math.x86" />
         <ComponentGroupRef Id="_Builtin_float.x86" />
         <ComponentGroupRef Id="_Concurrency.x86" />
         <ComponentGroupRef Id="_Differentiation.x86" />
@@ -2299,12 +3716,41 @@
         <ComponentGroupRef Id="_RegexParser.x86" />
         <ComponentGroupRef Id="_StringProcessing.x86" />
         <ComponentGroupRef Id="_Volatile.x86" />
+        <ComponentGroupRef Id="dispatch.x86" />
+        <ComponentGroupRef Id="swiftDispatch.x86" />
+
+        <ComponentGroupRef Id="CoreFoundation.x86" />
+        <ComponentGroupRef Id="FoundationDependencies.x86" />
+        <ComponentGroupRef Id="libAndroid.x86" />
+        <ComponentGroupRef Id="libBlocksRuntime.x86" />
+        <ComponentGroupRef Id="libCxx.x86" />
+        <ComponentGroupRef Id="libCxxStdlib.x86" />
+        <ComponentGroupRef Id="libDistributed.x86" />
+        <ComponentGroupRef Id="libFoundation.x86" />
+        <ComponentGroupRef Id="libFoundationEssentials.x86" />
+        <ComponentGroupRef Id="libFoundationInternationalization.x86" />
+        <ComponentGroupRef Id="libFoundationNetworking.x86" />
+        <ComponentGroupRef Id="libFoundationXML.x86" />
+        <ComponentGroupRef Id="libObservation.x86" />
+        <ComponentGroupRef Id="libRegexBuilder.x86" />
+        <ComponentGroupRef Id="libSwift.x86" />
+        <ComponentGroupRef Id="libSwiftOnoneSupport.x86" />
+        <ComponentGroupRef Id="libSwiftRemoteMirror.x86" />
+        <ComponentGroupRef Id="libSynchronization.x86" />
+        <ComponentGroupRef Id="lib_math.x86" />
+        <ComponentGroupRef Id="lib_Builtin_float.x86" />
+        <ComponentGroupRef Id="lib_Concurrency.x86" />
+        <ComponentGroupRef Id="lib_Differentiation.x86" />
+        <ComponentGroupRef Id="lib_FoundationCShims.x86" />
+        <ComponentGroupRef Id="lib_FoundationCollections.x86" />
+        <ComponentGroupRef Id="lib_FoundationUnicode.x86" />
+        <ComponentGroupRef Id="lib_RegexParser.x86" />
+        <ComponentGroupRef Id="lib_StringProcessing.x86" />
+        <ComponentGroupRef Id="lib_Volatile.x86" />
+        <ComponentGroupRef Id="libdispatch.x86" />
+        <ComponentGroupRef Id="libswiftDispatch.x86" />
 
         <ComponentGroupRef Id="Registrar.x86" />
-
-        <?if $(ANDROID_INCLUDE_DS2) = True?>
-          <ComponentGroupRef Id="ds2.x86" />
-        <?endif?>
       </Feature>
     <?endif?>
   </Package>

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -32,6 +32,10 @@
   <String Id="Sdk_ProductName_Windows_arm64" Value="Swift Windows SDK (ARM64)" />
   <String Id="Sdk_ProductName_Windows_amd64" Value="Swift Windows SDK (AMD64)" />
   <String Id="Sdk_ProductName_Windows_x86" Value="Swift Windows SDK (X86)" />
+  <String Id="Plt_ProductName_Android_arm64" Value="Swift Android Platform Support (ARM64)" />
+  <String Id="Plt_ProductName_Android_armv7" Value="Swift Android Platform Support (ARMv7)" />
+  <String Id="Plt_ProductName_Android_amd64" Value="Swift Android Platform Support (AMD64)" />
+  <String Id="Plt_ProductName_Android_x86" Value="Swift Android Platform Support (X86)" />
   <String Id="Plt_ProductName_Windows_arm64" Value="Swift Windows Platform Support (ARM64)" />
   <String Id="Plt_ProductName_Windows_amd64" Value="Swift Windows Platform Support (AMD64)" />
   <String Id="Plt_ProductName_Windows_x86" Value="Swift Windows Platform Support (X86)" />


### PR DESCRIPTION
This updates the android packaging to include the new experimental SDK as the default SDK. It additionally packages up the static runtime and brings the packaging layout in line with the Windows SDK packaging. It is able to sufficiently remove the dependency on the legacy SDK in the build to be useful.