### PR TITLE
Add new SwiftPM DLL to windows installer

### DIFF
--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -769,6 +769,9 @@
         <File Source="$(ToolchainRoot)\usr\bin\SPMBuildCore.dll" />
       </Component>
       <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\SwiftBuildSupport.dll" />
+      </Component>
+      <Component>
         <File Source="$(ToolchainRoot)\usr\bin\SwiftSDKCommand.dll" />
       </Component>
       <Component>


### PR DESCRIPTION
I'm fixing up a Windows build issue in https://github.com/swiftlang/swift-package-manager/pull/9824, add the corresponding DLL to the installer