### PR TITLE
WiX: always package `mimalloc-redirect`

### DIFF
--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -531,9 +531,8 @@
         <File Source="$(ToolchainRoot)\usr\bin\mimalloc.dll" />
       </Component>
       <Component>
-        <?if $(ProductArchitecture) = "amd64" ?>
-          <File Source="$(ToolchainRoot)\usr\bin\mimalloc-redirect.dll" />
-        <?elseif $(ProductArchitecture) = "arm64" ?>
+        <File Source="$(ToolchainRoot)\usr\bin\mimalloc-redirect.dll" />
+        <?if $(ProductArchitecture) = "arm64" ?>
           <File Source="$(ToolchainRoot)\usr\bin\mimalloc-redirect-arm64.dll" />
         <?endif?>
       </Component>


### PR DESCRIPTION
This is always referenced and is not architecture dependent as the module is built for the particular host.