### PR TITLE
WiX: package _PM-prefixed SwiftSyntax

### DIFF
--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -778,7 +778,30 @@
         <File Source="$(ToolchainRoot)\usr\bin\Workspace.dll" />
       </Component>
 
-      <!-- FIXME(compnerd) we should include the SPM import libraries -->
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftBasicFormat.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftDiagnostics.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftIDEUtils.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftParser.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftParserDiagnostics.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftRefactor.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftSyntax.dll" />
+      </Component>
+      <Component>
+        <File Source="$(ToolchainRoot)\usr\bin\_PMSwiftSyntaxBuilder.dll" />
+      </Component>
     </ComponentGroup>
 
     <?if True == False?>


### PR DESCRIPTION
Needed after https://github.com/swiftlang/swift-package-manager/commit/35fd89aa7515499e9cb642ecbf1a6d96879ee527

Also removes outdated FIXME