### PR TITLE
Fix Windows build failure caused by ICU revert

### DIFF
--- a/platforms/Windows/platforms/_FoundationUnicode.wxi
+++ b/platforms/Windows/platforms/_FoundationUnicode.wxi
@@ -166,24 +166,6 @@
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\measure.h" />
   </Component>
   <Component DiskId="$(var.Disk)">
-    <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messageformat2.h" />
-  </Component>
-  <Component DiskId="$(var.Disk)">
-    <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messageformat2_arguments.h" />
-  </Component>
-  <Component DiskId="$(var.Disk)">
-    <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messageformat2_data_model.h" />
-  </Component>
-  <Component DiskId="$(var.Disk)">
-    <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messageformat2_data_model_names.h" />
-  </Component>
-  <Component DiskId="$(var.Disk)">
-    <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messageformat2_formattable.h" />
-  </Component>
-  <Component DiskId="$(var.Disk)">
-    <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messageformat2_function_registry.h" />
-  </Component>
-  <Component DiskId="$(var.Disk)">
     <File Source="$(SDKRoot)\usr\include\_foundation_unicode\messagepattern.h" />
   </Component>
   <Component DiskId="$(var.Disk)">


### PR DESCRIPTION
Remove the file references for the headers removed in https://github.com/swiftlang/swift-foundation-icu/pull/94

Resolves: rdar://176420917