### PR TITLE
Add _FoundationInternationalizationData library to Windows installer

### DIFF
--- a/platforms/Windows/platforms/FoundationInternationalizationDataHeaders.wxs
+++ b/platforms/Windows/platforms/FoundationInternationalizationDataHeaders.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <ComponentGroup Id="_FoundationInternationalizationData" Directory="SDK_usr_include__FoundationInternationalizationData" Source="$(SDKRoot)\usr\include\_FoundationInternationalizationData">
+      <File Name="ListFormatData.h" />
+      <File Name="InternationalizationDataMacros.h" />
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/platforms/Windows/platforms/android/android.wixproj
+++ b/platforms/Windows/platforms/android/android.wixproj
@@ -23,7 +23,7 @@
     <Compile Include="..\BlocksRuntimeHeaders.wxs" Link="BlocksRuntimeHeaders.wxs" />
     <Compile Include="..\DispatchHeaders.wxs" Link="DispatchHeaders.wxs" />
     <Compile Include="..\FoundationCShimsHeaders.wxs" Link="FoundationCShimsHeaders.wxs" />
-    <Compile Include="..\FoundationInternationalizationData.wxs" Link="FoundationInternationalizationData.wxs" />
+    <Compile Include="..\FoundationInternationalizationDataHeaders.wxs" Link="FoundationInternationalizationDataHeaders.wxs" />
     <Compile Include="..\FoundationUnicodeHeaders.wxs" Link="FoundationUnicodeHeaders.wxs" />
     <Compile Include="..\SwiftRemoteMirrorHeaders.wxs" Link="SwiftRemoteMirrorHeaders.wxs" />
   </ItemGroup>

--- a/platforms/Windows/platforms/android/android.wixproj
+++ b/platforms/Windows/platforms/android/android.wixproj
@@ -23,6 +23,7 @@
     <Compile Include="..\BlocksRuntimeHeaders.wxs" Link="BlocksRuntimeHeaders.wxs" />
     <Compile Include="..\DispatchHeaders.wxs" Link="DispatchHeaders.wxs" />
     <Compile Include="..\FoundationCShimsHeaders.wxs" Link="FoundationCShimsHeaders.wxs" />
+    <Compile Include="..\FoundationInternationalizationData.wxs" Link="FoundationInternationalizationData.wxs" />
     <Compile Include="..\FoundationUnicodeHeaders.wxs" Link="FoundationUnicodeHeaders.wxs" />
     <Compile Include="..\SwiftRemoteMirrorHeaders.wxs" Link="SwiftRemoteMirrorHeaders.wxs" />
   </ItemGroup>

--- a/platforms/Windows/platforms/android/android.wxs
+++ b/platforms/Windows/platforms/android/android.wxs
@@ -38,7 +38,7 @@
     <?define SDKDispatchModuleDirectoryNames = Dispatch?>
     <?define SDKFoundationComponentGroups = _FoundationCollections;_FoundationUnicode;Foundation;FoundationEssentials;FoundationInternationalization;FoundationNetworking;FoundationXML?>
     <?define SDKFoundationModuleDirectoryNames = _FoundationCollections;Foundation;FoundationEssentials;FoundationInternationalization;FoundationNetworking;FoundationXML?>
-    <?define SDKFoundationStaticComponentGroups = CoreFoundation;FoundationDependencies;lib_FoundationCShims?>
+    <?define SDKFoundationStaticComponentGroups = CoreFoundation;FoundationDependencies;lib_FoundationCShims;lib_FoundationInternationalizationData?>
     <?define SDKStandardModules = _Builtin_float;_Concurrency;_Differentiation;_RegexParser;_StringProcessing;_Volatile;Distributed;Observation;RegexBuilder;Swift;SwiftOnoneSupport;Synchronization?>
     <?define SDKModuleDirectoryNames = $(SDKPlatformOverlayModules);$(SDKCXXInteropModules);$(SDKDispatchModuleDirectoryNames);$(SDKFoundationModuleDirectoryNames);$(SDKStandardModules)?>
 
@@ -133,6 +133,7 @@
                 <Directory Name="include">
                   <Directory Id="SDK_usr_include__foundation_unicode" Name="_foundation_unicode" DiskId="1" />
                   <Directory Id="SDK_usr_include__FoundationCShims" Name="_FoundationCShims" DiskId="1" />
+                  <Directory Id="SDK_usr_include__FoundationInternationalizationData" Name="_FoundationInternationalizationData" DiskId="1" />
                   <Directory Id="SDK_usr_include_Block" Name="Block" DiskId="1" />
                   <Directory Id="SDK_usr_include_dispatch" Name="dispatch" DiskId="1" />
                   <Directory Id="SDK_usr_include_os" Name="os" DiskId="1" />
@@ -364,6 +365,30 @@
     <?if $(IncludeX86) == True?>
       <ComponentGroup Id="lib_FoundationCShims.x86" Directory="SDK_usr_lib_swift_static_android_x86">
         <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_FoundationCShims.a" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.arm64" Directory="SDK_usr_lib_swift_static_android_arm64">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\android\aarch64\lib_FoundationInternationalizationData.a" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.arm" Directory="SDK_usr_lib_swift_static_android_arm">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\android\armv7\lib_FoundationInternationalizationData.a" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeX64) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.x64" Directory="SDK_usr_lib_swift_static_android_x64">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\android\x86_64\lib_FoundationInternationalizationData.a" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeX86) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.x86" Directory="SDK_usr_lib_swift_static_android_x86">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\android\i686\lib_FoundationInternationalizationData.a" />
       </ComponentGroup>
     <?endif?>
 
@@ -2170,6 +2195,7 @@
 
     <Feature Id="SDK" AllowAbsent="no" Title="!(loc.Plt_ProductName_Android)">
       <ComponentGroupRef Id="_FoundationCShims" />
+      <ComponentGroupRef Id="_FoundationInternationalizationData" />
       <ComponentGroupRef Id="_FoundationUnicode" />
       <ComponentGroupRef Id="APINotes" />
       <ComponentGroupRef Id="BlocksRuntime" />

--- a/platforms/Windows/platforms/windows/windows.wixproj
+++ b/platforms/Windows/platforms/windows/windows.wixproj
@@ -21,6 +21,7 @@
     <Compile Include="..\BlocksRuntimeHeaders.wxs" Link="BlocksRuntimeHeaders.wxs" />
     <Compile Include="..\DispatchHeaders.wxs" Link="DispatchHeaders.wxs" />
     <Compile Include="..\FoundationCShimsHeaders.wxs" Link="FoundationCShimsHeaders.wxs" />
+    <Compile Include="..\FoundationInternationalizationData.wxs" Link="FoundationInternationalizationData.wxs" />
     <Compile Include="..\FoundationUnicodeHeaders.wxs" Link="FoundationUnicodeHeaders.wxs" />
     <Compile Include="..\SwiftRemoteMirrorHeaders.wxs" Link="SwiftRemoteMirrorHeaders.wxs" />
   </ItemGroup>

--- a/platforms/Windows/platforms/windows/windows.wixproj
+++ b/platforms/Windows/platforms/windows/windows.wixproj
@@ -21,7 +21,7 @@
     <Compile Include="..\BlocksRuntimeHeaders.wxs" Link="BlocksRuntimeHeaders.wxs" />
     <Compile Include="..\DispatchHeaders.wxs" Link="DispatchHeaders.wxs" />
     <Compile Include="..\FoundationCShimsHeaders.wxs" Link="FoundationCShimsHeaders.wxs" />
-    <Compile Include="..\FoundationInternationalizationData.wxs" Link="FoundationInternationalizationData.wxs" />
+    <Compile Include="..\FoundationInternationalizationDataHeaders.wxs" Link="FoundationInternationalizationDataHeaders.wxs" />
     <Compile Include="..\FoundationUnicodeHeaders.wxs" Link="FoundationUnicodeHeaders.wxs" />
     <Compile Include="..\SwiftRemoteMirrorHeaders.wxs" Link="SwiftRemoteMirrorHeaders.wxs" />
   </ItemGroup>

--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -38,7 +38,7 @@
     <?define SDKDispatchModuleDirectoryNames = Dispatch?>
     <?define SDKFoundationComponentGroups = _FoundationCollections;_FoundationUnicode;Foundation;FoundationEssentials;FoundationInternationalization;FoundationNetworking;FoundationXML?>
     <?define SDKFoundationModuleDirectoryNames = _FoundationCollections;Foundation;FoundationEssentials;FoundationInternationalization;FoundationNetworking;FoundationXML?>
-    <?define SDKFoundationStaticComponentGroups = CoreFoundation;FoundationDependencies;lib_FoundationCShims?>
+    <?define SDKFoundationStaticComponentGroups = CoreFoundation;FoundationDependencies;lib_FoundationCShims;lib_FoundationInternationalizationData?>
     <?define SDKStandardModules = _Builtin_float;_Concurrency;_Differentiation;_RegexParser;_StringProcessing;_Volatile;Distributed;Observation;RegexBuilder;Runtime;Swift;SwiftOnoneSupport;Synchronization?>
     <?define SDKModuleDirectoryNames = $(SDKPlatformOverlayModules);$(SDKCXXInteropModules);$(SDKDispatchModuleDirectoryNames);$(SDKFoundationModuleDirectoryNames);$(SDKStandardModules)?>
 
@@ -135,6 +135,7 @@
                 <Directory Name="include">
                   <Directory Id="SDK_usr_include__foundation_unicode" Name="_foundation_unicode" DiskId="1" />
                   <Directory Id="SDK_usr_include__FoundationCShims" Name="_FoundationCShims" DiskId="1" />
+                  <Directory Id="SDK_usr_include__FoundationInternationalizationData" Name="_FoundationInternationalizationData" DiskId="1" />
                   <Directory Id="SDK_usr_include_Block" Name="Block" DiskId="1" />
                   <Directory Id="SDK_usr_include_dispatch" Name="dispatch" DiskId="1" />
                   <Directory Id="SDK_usr_include_os" Name="os" DiskId="1" />
@@ -337,6 +338,24 @@
     <?if $(IncludeX86) == True?>
       <ComponentGroup Id="lib_FoundationCShims.x86" Directory="SDK_usr_lib_swift_static_windows_x86">
         <File Source="$(SDKRoot)\usr\lib\swift_static\windows\i686\_FoundationCShims.lib" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeARM64) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.arm64" Directory="SDK_usr_lib_swift_static_windows_arm64">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\windows\aarch64\_FoundationInternationalizationData.lib" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeX64) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.x64" Directory="SDK_usr_lib_swift_static_windows_x64">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\windows\x86_64\_FoundationInternationalizationData.lib" />
+      </ComponentGroup>
+    <?endif?>
+
+    <?if $(IncludeX86) == True?>
+      <ComponentGroup Id="lib_FoundationInternationalizationData.x86" Directory="SDK_usr_lib_swift_static_windows_x86">
+        <File Source="$(SDKRoot)\usr\lib\swift_static\windows\i686\_FoundationInternationalizationData.lib" />
       </ComponentGroup>
     <?endif?>
 
@@ -1792,6 +1811,7 @@
       <ComponentGroupRef Id="SwiftRemoteMirror" />
       <ComponentGroupRef Id="SwiftShims" />
       <ComponentGroupRef Id="_FoundationCShims" />
+      <ComponentGroupRef Id="_FoundationInternationalizationData" />
       <ComponentGroupRef Id="_FoundationUnicode" />
     </Feature>
 


### PR DESCRIPTION
This duplicates the configuration of `_FoundationCShims` to add the `_FoundationInternationalizationData` library to the windows installer