### PR TITLE
[6.4] WiX: remove swift/bridging header from installer

### DIFF
--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -255,16 +255,6 @@
       <Component>
         <File Source="$(ToolchainRoot)\usr\lib\swift\swiftToCxx\experimental-interoperability-version.json" />
       </Component>
-
-      <Component Directory="toolchain_$(VariantName)_usr_include_swift">
-        <File Source="$(ToolchainRoot)\usr\include\swift\bridging.modulemap" />
-      </Component>
-      <Component Directory="toolchain_$(VariantName)_usr_include_swift">
-        <File Source="$(ToolchainRoot)\usr\include\swift\bridging" />
-      </Component>
-      <Component Directory="toolchain_$(VariantName)_usr_include_swift">
-        <File Source="$(ToolchainRoot)\usr\include\module.modulemap" />
-      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="SwiftDemangle">


### PR DESCRIPTION
**Explanation:** Place the swift/bridging header in Clang's resource directory, so that it is automatically `#include`-able by both clang and swift. This file is already `#include`-able on Apple's Xcode toolchains (which as different search pathes), but NOT OSS toolchains; this cherry-pick brings the two into alignment for the 6.4 release.

**Scope:** header files that `#include <swift/bridging>`, i.e., those written for Swift/C[++] interop

**Risk:** the fact that OSS toolchains behave differently than Apple toolchains means that some projects may have workarounds that conflict with this change. I will leave it to the discretion of the branch managers + reviewers whether this is an acceptable risk.

**Testing:** CI testing

**Original PR:** https://github.com/swiftlang/llvm-project/pull/12861 https://github.com/swiftlang/swift/pull/88748 https://github.com/swiftlang/swift-installer-scripts/pull/532

**Reviewed by:** @egorzhdan @etcwilde @compnerd @xazax-hun @finagolfin 

**Issues:** 

**Details:**

These files are being moved into the Clang resource directory, so we no longer need to install them to $(ToolchainRoot)\usr\include.

(cherry picked from commit 027564c350a244d3449066ed293513c2c29b8ead)

Paired with https://github.com/swiftlang/swift/pull/90358 and https://github.com/swiftlang/llvm-project/pull/13297