### PR TITLE
[WiX] Always sign catalogs with certificate

### DIFF
--- a/platforms/Windows/RuntimeWin32Assemblies.targets
+++ b/platforms/Windows/RuntimeWin32Assemblies.targets
@@ -63,6 +63,7 @@
         WorkingDirectory="%(_RuntimeWin32Assembly.AssemblyDirectory)"
         Command="&quot;$(MakeCatToolPath)makecat.exe&quot; -v &quot;%(_RuntimeWin32Assembly.CatalogDefinition)&quot;" />
 
-    <Exec Command="$(CatalogSignTool) &quot;%(_RuntimeWin32Assembly.Catalog)&quot;" />
+    <Exec Condition=" '$(CERTIFICATE)' != '' "
+          Command="$(CatalogSignTool) &quot;%(_RuntimeWin32Assembly.Catalog)&quot;" />
   </Target>
 </Project>

--- a/platforms/Windows/RuntimeWin32Assemblies.targets
+++ b/platforms/Windows/RuntimeWin32Assemblies.targets
@@ -13,7 +13,7 @@
   </Target>
 
   <Target Name="GenerateRuntimeWin32Assemblies"
-          DependsOnTargets="_DefineRuntimeWin32AssemblyConstants;FindWindowsSDKTools;FindSignTool"
+          DependsOnTargets="_DefineRuntimeWin32AssemblyConstants;FindWindowsSDKTools;FindCatalogSignTool"
           BeforeTargets="CoreCompile;Compile">
     <PropertyGroup>
       <_RuntimeRoot Condition="'$(ProductArchitecture)' == 'x86'">$(WindowsRuntimeX86)</_RuntimeRoot>
@@ -63,7 +63,6 @@
         WorkingDirectory="%(_RuntimeWin32Assembly.AssemblyDirectory)"
         Command="&quot;$(MakeCatToolPath)makecat.exe&quot; -v &quot;%(_RuntimeWin32Assembly.CatalogDefinition)&quot;" />
 
-    <Exec Condition="'$(SignOutput)' == 'true'"
-          Command="$(SignTool) &quot;%(_RuntimeWin32Assembly.Catalog)&quot;" />
+    <Exec Command="$(CatalogSignTool) &quot;%(_RuntimeWin32Assembly.Catalog)&quot;" />
   </Target>
 </Project>

--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -76,10 +76,8 @@
        certificate whose key does not rotate. Azure Trusted Signing issues short-lived,
        daily-rotating certificates and therefore cannot be used to sign catalogs. -->
   <Target Name="FindCatalogSignTool" DependsOnTargets="FindSignTool">
-    <!-- Catalog signing is mandatory for a functional shared assembly, so a missing
-         certificate is a hard error rather than a silently unsigned (unusable) build. -->
-    <Error Condition=" '$(CERTIFICATE)' == '' "
-           Text="Catalog signing requires a certificate. Set CERTIFICATE (and PASSPHRASE) to a stable, long-lived signing certificate." />
+    <Warning Condition=" '$(CERTIFICATE)' == '' "
+             Text="Catalog signing skipped: no CERTIFICATE provided. The shared runtime will NOT install. Set CERTIFICATE (and PASSPHRASE) to produce an installable build." />
 
     <PropertyGroup>
       <CatalogSignTool>"$(SignToolPath)signtool.exe" sign $(VerboseFlag)/tr http://timestamp.digicert.com /fd sha256 /td sha256 /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" </CatalogSignTool>

--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -69,6 +69,23 @@
            Text="Unable to locate signtool.exe. Set SignToolPath to the Windows SDK bin directory." />
   </Target>
 
+  <!-- Signing flow for the Win32 side-by-side (SxS) assembly verification catalogs.
+       This is intentionally kept separate from the Authenticode $(SignTool) above:
+       the publicKeyToken baked into each assembly manifest is derived from the signing
+       certificate's public key, so the catalog must be signed by a stable, long-lived
+       certificate whose key does not rotate. Azure Trusted Signing issues short-lived,
+       daily-rotating certificates and therefore cannot be used to sign catalogs. -->
+  <Target Name="FindCatalogSignTool" DependsOnTargets="FindSignTool">
+    <!-- Catalog signing is mandatory for a functional shared assembly, so a missing
+         certificate is a hard error rather than a silently unsigned (unusable) build. -->
+    <Error Condition=" '$(CERTIFICATE)' == '' "
+           Text="Catalog signing requires a certificate. Set CERTIFICATE (and PASSPHRASE) to a stable, long-lived signing certificate." />
+
+    <PropertyGroup>
+      <CatalogSignTool>"$(SignToolPath)signtool.exe" sign $(VerboseFlag)/tr http://timestamp.digicert.com /fd sha256 /td sha256 /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" </CatalogSignTool>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="FindWindowsSDKTools" DependsOnTargets="FindWindowsSDK">
     <PropertyGroup>
       <ManifestToolPath Condition=" '$(ManifestToolPath)' == '' ">$(WindowsSDKToolsPath)</ManifestToolPath>


### PR DESCRIPTION
Windows requires that the catalogs for the SxS assemblies be signed with the same certificate as the `publicKeyToken` referenced in the assembly manifests. This means that Azure Trusted Signing cannot be used for this case since Trusted Signing issues ephemeral short-lived certificates.

* Use a separate tool to sign the catalogs that always uses certificate + passphrase.
* Warn when no certificate is provided. This is because unsigned catalogs for SxS assemblies are rejected by Windows.