### PR TITLE
[Windows] Remove EntityLinker.xcspec from the manifest

### DIFF
--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -184,7 +184,6 @@
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\Embedded-Shared.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\Embedded-Simulator.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\EmbeddedBinaryValidationUtility.xcspec" />
-      <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\EntityLinker.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\GenerateAppPlaygroundAssetCatalog.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\GenerateTextureAtlas.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\IBCompiler.xcspec" />


### PR DESCRIPTION
`EntityLinker.xcspec` was added to `swift-build` in https://github.com/swiftlang/swift-build/pull/1406 and then reverted in https://github.com/swiftlang/swift-build/pull/1406. The re-apply does not add the file again (https://github.com/t-rasmud/swift-build/commit/b38d49f23a41b7b7021f895e89e4174e8bee5376)