### PR TITLE
Revert "[Windows] Remove EntityLinker.xcspec from the manifest"

### DIFF
--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -184,6 +184,7 @@
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\Embedded-Shared.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\Embedded-Simulator.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\EmbeddedBinaryValidationUtility.xcspec" />
+      <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\EntityLinker.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\GenerateAppPlaygroundAssetCatalog.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\GenerateTextureAtlas.xcspec" />
       <File Source="$(ToolchainRoot)\usr\share\pm\SwiftBuild_SWBApplePlatform.resources\IBCompiler.xcspec" />


### PR DESCRIPTION
Reverts swiftlang/swift-installer-scripts#541

Added `EntityLinker.xcspec` to `swift-build` in https://github.com/swiftlang/swift-build/commit/765e6fbdd9fea6cf921a8f8ae07a5c1fb0ab5707