### PR TITLE
[6.4] WiX: include swift_RegexParser in the toolchain private runtime

### DIFF
--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -561,6 +561,9 @@
       <Component Directory="toolchain_$(VariantName)_usr_bin_swift_Concurrency">
         <File Source="$(ToolchainRoot)\usr\bin\swift_Concurrency\swift_Concurrency.dll" />
       </Component>
+      <Component Directory="toolchain_$(VariantName)_usr_bin_swift_RegexParser">
+        <File Source="$(ToolchainRoot)\usr\bin\swift_RegexParser\swift_RegexParser.dll" />
+      </Component>
       <Component Directory="toolchain_$(VariantName)_usr_bin_swift_StringProcessing">
         <File Source="$(ToolchainRoot)\usr\bin\swift_StringProcessing\swift_StringProcessing.dll" />
       </Component>

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -18,6 +18,7 @@
       <Directory Id="toolchain_$(VariantName)_usr_bin_dispatch" Name="dispatch" />
       <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationEssentials" Name="FoundationEssentials" />
       <Directory Id="toolchain_$(VariantName)_usr_bin_swift_Concurrency" Name="swift_Concurrency" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_RegexParser" Name="swift_RegexParser" />
       <Directory Id="toolchain_$(VariantName)_usr_bin_swift_StringProcessing" Name="swift_StringProcessing" />
       <Directory Id="toolchain_$(VariantName)_usr_bin_swiftCore" Name="swiftCore" />
       <Directory Id="toolchain_$(VariantName)_usr_bin_swiftCRT" Name="swiftCRT" />


### PR DESCRIPTION
This pull request updates the Windows installer configuration to include the new `swift_RegexParser` component in the toolchain. The main changes add the necessary directory and file references for this component.

**Installer configuration updates:**

* Added a new directory entry for `swift_RegexParser` under the toolchain's `usr/bin` section in `bld.wxi`.
* Registered the `swift_RegexParser.dll` file as a component to be installed, ensuring it is included in Windows builds.