### PR TITLE
WiX: package FoundationNetworking as a SxS runtime

### DIFF
--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -24,6 +24,7 @@
     <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
       <Directory Id="toolchain_$(VariantName)_usr_bin_Foundation" Name="Foundation" />
       <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationInternationalization" Name="FoundationInternationalization" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationNetworking" Name="FoundationNetworking" />
       <Directory Id="toolchain_$(VariantName)_usr_bin__FoundationICU" Name="_FoundationICU" />
     </DirectoryRef>
 
@@ -822,6 +823,9 @@
       </Component>
       <Component Directory="toolchain_$(VariantName)_usr_bin_FoundationInternationalization">
         <File Source="$(ToolchainRoot)\usr\bin\FoundationInternationalization\FoundationInternationalization.dll" />
+      </Component>
+      <Component Directory="toolchain_$(VariantName)_usr_bin_FoundationNetworking">
+	<File Source="$(ToolchainRoot)\usr\bin\FoundationNetworking\FoundationNetworking.dll" />
       </Component>
       <Component Directory="toolchain_$(VariantName)_usr_bin__FoundationICU">
         <File Source="$(ToolchainRoot)\usr\bin\_FoundationICU\_FoundationICU.dll" />


### PR DESCRIPTION
The Swift Package Manager uses Foundation Networking and thus the runtime must be bundled as a SxS private assembly. This should hopefully allow the toolchain to be usable.

Fixes: swiftlang/swift#90861