### PR TITLE
WiX: introduce a new PRT MSI

### DIFF
--- a/platforms/Windows/SideBySideUpgradeStrategy.props
+++ b/platforms/Windows/SideBySideUpgradeStrategy.props
@@ -25,6 +25,8 @@
     <DbgNoAssertsUpgradeCode>{6F26625B-7662-4631-8E0E-F2244339ED37}</DbgNoAssertsUpgradeCode>
     <IdeAssertsUpgradeCode>{8DD91C86-D13D-490B-B06B-9522A9CF504C}</IdeAssertsUpgradeCode>
     <IdeNoAssertsUpgradeCode>{C5519168-CF7B-4127-98B7-D886D9789B42}</IdeNoAssertsUpgradeCode>
+    <PrtAssertsUpgradeCode>{1902DEBA-CF54-48E4-89FE-122E53BF4A33}</PrtAssertsUpgradeCode>
+    <PrtNoAssertsUpgradeCode>{954AA86D-A593-4DDF-AB04-8B463EA8A5AE}</PrtNoAssertsUpgradeCode>
     <RTLUpgradeCode>{F9BA01C7-0C7C-4898-90BD-9D6BB308F0B3}</RTLUpgradeCode>
     <AndroidPlatformUpgradeCode>{313B9C1F-D5B5-4FED-B7E0-138F1EE6B26A}</AndroidPlatformUpgradeCode>
     <WindowsPlatformUpgradeCode>{01AFF1CF-A025-41B6-BCBC-728D794353FD}</WindowsPlatformUpgradeCode>
@@ -76,6 +78,8 @@
       DbgNoAssertsUpgradeCode=$(DbgNoAssertsUpgradeCode);
       IdeAssertsUpgradeCode=$(IdeAssertsUpgradeCode);
       IdeNoAssertsUpgradeCode=$(IdeNoAssertsUpgradeCode);
+      PrtAssertsUpgradeCode=$(PrtAssertsUpgradeCode);
+      PrtNoAssertsUpgradeCode=$(PrtNoAssertsUpgradeCode);
       RTLUpgradeCode=$(RTLUpgradeCode);
       AndroidPlatformUpgradeCode=$(AndroidPlatformUpgradeCode);
       WindowsPlatformUpgradeCode=$(WindowsPlatformUpgradeCode);

--- a/platforms/Windows/bld/bld.wxi
+++ b/platforms/Windows/bld/bld.wxi
@@ -29,21 +29,6 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(VariantUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
-      <Directory Id="toolchain_$(VariantName)_usr_bin_BlocksRuntime" Name="BlocksRuntime" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_dispatch" Name="dispatch" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationEssentials" Name="FoundationEssentials" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_Concurrency" Name="swift_Concurrency" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_RegexParser" Name="swift_RegexParser" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_StringProcessing" Name="swift_StringProcessing" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftCore" Name="swiftCore" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftCRT" Name="swiftCRT" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftDispatch" Name="swiftDispatch" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftObservation" Name="swiftObservation" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftSynchronization" Name="swiftSynchronization" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftWinSDK" Name="swiftWinSDK" />
-    </DirectoryRef>
-
     <DirectoryRef Id="toolchain_$(VariantName)_usr_include">
       <Directory Id="toolchain_$(VariantName)_usr_include_llvm_c" Name="llvm-c" />
       <Directory Id="toolchain_$(VariantName)_usr_include_swift" Name="swift" />
@@ -304,21 +289,6 @@
       <?endif?>
     </ComponentGroup>
 
-    <ComponentGroup Id="SxSSwiftRuntime">
-      <File Directory="toolchain_$(VariantName)_usr_bin_BlocksRuntime" Source="$(ToolchainRoot)\usr\bin\BlocksRuntime\BlocksRuntime.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_dispatch" Source="$(ToolchainRoot)\usr\bin\dispatch\dispatch.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationEssentials" Source="$(ToolchainRoot)\usr\bin\FoundationEssentials\FoundationEssentials.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swift_Concurrency" Source="$(ToolchainRoot)\usr\bin\swift_Concurrency\swift_Concurrency.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swift_RegexParser" Source="$(ToolchainRoot)\usr\bin\swift_RegexParser\swift_RegexParser.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swift_StringProcessing" Source="$(ToolchainRoot)\usr\bin\swift_StringProcessing\swift_StringProcessing.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftCore" Source="$(ToolchainRoot)\usr\bin\swiftCore\swiftCore.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftCRT" Source="$(ToolchainRoot)\usr\bin\swiftCRT\swiftCRT.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftDispatch" Source="$(ToolchainRoot)\usr\bin\swiftDispatch\swiftDispatch.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftObservation" Source="$(ToolchainRoot)\usr\bin\swiftObservation\swiftObservation.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftSynchronization" Source="$(ToolchainRoot)\usr\bin\swiftSynchronization\swiftSynchronization.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftWinSDK" Source="$(ToolchainRoot)\usr\bin\swiftWinSDK\swiftWinSDK.dll" />
-    </ComponentGroup>
-
     <ComponentGroup Id="Configuration">
       <File Directory="$(ToolchainVersionedVariantDirectory)" Source="$(ToolchainRoot)\ToolchainInfo.plist" />
     </ComponentGroup>
@@ -361,8 +331,6 @@
       <ComponentGroupRef Id="FoundationMacros" />
       <ComponentGroupRef Id="TestingMacros" />
       <ComponentGroupRef Id="mimalloc" />
-      <ComponentGroupRef Id="SxSSwiftRuntime" />
-
       <ComponentGroupRef Id="ClangResources_$(VariantName)" />
       <ComponentGroupRef Id="SwiftClangResources_$(VariantName)" />
       <ComponentGroupRef Id="SwiftStaticClangResources_$(VariantName)" />

--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -70,6 +70,7 @@
     <ProjectReference Include="..\cli\asserts\cli.asserts.wixproj" BindName="cli.asserts" />
     <ProjectReference Include="..\dbg\asserts\dbg.asserts.wixproj" BindName="dbg.asserts" />
     <ProjectReference Include="..\ide\asserts\ide.asserts.wixproj" BindName="ide.asserts" />
+    <ProjectReference Include="..\prt\asserts\prt.asserts.wixproj" BindName="prt.asserts" />
     <ProjectReference Include="..\res\res.wixproj" BindName="res" />
     <ProjectReference Include="..\python\python.wixproj" BindName="python" />
   </ItemGroup>
@@ -79,6 +80,7 @@
     <ProjectReference Include="..\cli\noasserts\cli.noasserts.wixproj" BindName="cli.noasserts" />
     <ProjectReference Include="..\dbg\noasserts\dbg.noasserts.wixproj" BindName="dbg.noasserts" />
     <ProjectReference Include="..\ide\noasserts\ide.noasserts.wixproj" BindName="ide.noasserts" />
+    <ProjectReference Include="..\prt\noasserts\prt.noasserts.wixproj" BindName="prt.noasserts" />
   </ItemGroup>
 
   <ItemGroup>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -173,6 +173,7 @@
         <PackageGroupRef Id="CliAssertsPackage" />
         <PackageGroupRef Id="DbgAssertsPackage" />
         <PackageGroupRef Id="IdeAssertsPackage" />
+        <PackageGroupRef Id="PrtAssertsPackage" />
       </Container>
 
       <?if $(IncludeNoAsserts) == True?>
@@ -181,6 +182,7 @@
           <PackageGroupRef Id="CliNoAssertsPackage" />
           <PackageGroupRef Id="DbgNoAssertsPackage" />
           <PackageGroupRef Id="IdeNoAssertsPackage" />
+          <PackageGroupRef Id="PrtNoAssertsPackage" />
         </Container>
       <?endif?>
 
@@ -210,6 +212,11 @@
       <PackageGroupRef Id="IdeAssertsPackage" />
       <?if $(IncludeNoAsserts) == True?>
         <PackageGroupRef Id="IdeNoAssertsPackage" />
+      <?endif?>
+
+      <PackageGroupRef Id="PrtAssertsPackage" />
+      <?if $(IncludeNoAsserts) == True?>
+        <PackageGroupRef Id="PrtNoAssertsPackage" />
       <?endif?>
 
       <PackageGroupRef Id="ResPackage" />
@@ -328,6 +335,38 @@
         InstallCondition="OptionsInstallIDE = 1 and OptionsInstallNoAssertsToolchain = 1"
         DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
         <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+      </MsiPackage>
+    </PackageGroup>
+  </Fragment>
+  <?endif?>
+
+  <Fragment>
+    <PackageGroup Id="PrtAssertsPackage">
+      <MsiPackage
+        SourceFile="!(bindpath.prt.asserts)\prt.asserts.msi"
+        InstallCondition="OptionsInstallAssertsToolchain = 1"
+        DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+        <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        <MsiProperty Name="INSTALLBLD" Value="[OptionsInstallBLD]" />
+        <MsiProperty Name="INSTALLCLI" Value="[OptionsInstallCLI]" />
+        <MsiProperty Name="INSTALLDBG" Value="[OptionsInstallDBG]" />
+        <MsiProperty Name="INSTALLIDE" Value="[OptionsInstallIDE]" />
+      </MsiPackage>
+    </PackageGroup>
+  </Fragment>
+
+  <?if $(IncludeNoAsserts) == True?>
+  <Fragment>
+    <PackageGroup Id="PrtNoAssertsPackage">
+      <MsiPackage
+        SourceFile="!(bindpath.prt.noasserts)\prt.noasserts.msi"
+        InstallCondition="OptionsInstallNoAssertsToolchain = 1"
+        DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+        <MsiProperty Name="INSTALLROOT" Value="[InstallRoot]" />
+        <MsiProperty Name="INSTALLBLD" Value="[OptionsInstallBLD]" />
+        <MsiProperty Name="INSTALLCLI" Value="[OptionsInstallCLI]" />
+        <MsiProperty Name="INSTALLDBG" Value="[OptionsInstallDBG]" />
+        <MsiProperty Name="INSTALLIDE" Value="[OptionsInstallIDE]" />
       </MsiPackage>
     </PackageGroup>
   </Fragment>

--- a/platforms/Windows/cli/cli.wxi
+++ b/platforms/Windows/cli/cli.wxi
@@ -32,12 +32,6 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(VariantUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
-      <Directory Id="toolchain_$(VariantName)_usr_bin_Foundation" Name="Foundation" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationInternationalization" Name="FoundationInternationalization" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin__FoundationICU" Name="_FoundationICU" />
-    </DirectoryRef>
-
     <DirectoryRef Id="toolchain_$(VariantName)_usr_include">
       <Directory Id="toolchain_$(VariantName)_usr_include__InternalSwiftScan" Name="_InternalSwiftScan" />
       <Directory Id="toolchain_$(VariantName)_usr_include_clang_c" Name="clang-c" />
@@ -385,12 +379,6 @@
       <File Source="$(ToolchainRoot)\usr\bin\SwiftFormat.dll" />
     </ComponentGroup>
 
-    <ComponentGroup Id="SxSSwiftRuntime">
-      <File Directory="toolchain_$(VariantName)_usr_bin_Foundation" Source="$(ToolchainRoot)\usr\bin\Foundation\Foundation.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationInternationalization" Source="$(ToolchainRoot)\usr\bin\FoundationInternationalization\FoundationInternationalization.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin__FoundationICU" Source="$(ToolchainRoot)\usr\bin\_FoundationICU\_FoundationICU.dll" />
-    </ComponentGroup>
-
     <Feature Id="CLITools" AllowAbsent="no" Title="$(VariantProductName)">
       <ComponentGroupRef Id="clang" />
       <ComponentGroupRef Id="libclang" />
@@ -414,8 +402,6 @@
       <ComponentGroupRef Id="DocCRender" />
 
       <ComponentGroupRef Id="swift_format" />
-      <ComponentGroupRef Id="SxSSwiftRuntime" />
-
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
   </Package>

--- a/platforms/Windows/dbg/dbg.wxi
+++ b/platforms/Windows/dbg/dbg.wxi
@@ -25,10 +25,6 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(VariantUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftRemoteMirror" Name="swiftRemoteMirror" />
-    </DirectoryRef>
-
     <DirectoryRef Id="toolchain_$(VariantName)_usr_include">
       <Directory Id="toolchain_$(VariantName)_usr_include__InternalSwiftStaticMirror" Name="_InternalSwiftStaticMirror" />
     </DirectoryRef>
@@ -98,10 +94,6 @@
       <File Source="$(ToolchainRoot)\usr\lib\swift\_InternalSwiftStaticMirror\StaticMirrorMacros.h" />
     </ComponentGroup>
 
-    <ComponentGroup Id="SxSSwiftRuntime">
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftRemoteMirror" Source="$(ToolchainRoot)\usr\bin\swiftRemoteMirror\swiftRemoteMirror.dll" />
-    </ComponentGroup>
-
     <Feature Id="DebuggingTools" AllowAbsent="no" Title="$(VariantProductName)">
       <ComponentGroupRef Id="LLDB" />
       <ComponentGroupRef Id="LLDBServer" />
@@ -111,8 +103,6 @@
       <ComponentGroupRef Id="SwiftSynthesizeInterface" />
 
       <ComponentGroupRef Id="_InternalSwiftStaticMirror" />
-      <ComponentGroupRef Id="SxSSwiftRuntime" />
-
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
   </Package>

--- a/platforms/Windows/ide/ide.wxi
+++ b/platforms/Windows/ide/ide.wxi
@@ -25,11 +25,6 @@
     <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(VariantUpgradeCode)" />
     <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
 
-    <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
-      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationXML" Name="FoundationXML" />
-      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftRegexBuilder" Name="swiftRegexBuilder" />
-    </DirectoryRef>
-
     <DirectoryRef Id="toolchain_$(VariantName)_usr_include">
       <Directory Id="toolchain_$(VariantName)_usr_include_SourceKit" Name="SourceKit" />
     </DirectoryRef>
@@ -59,18 +54,11 @@
       <File Directory="toolchain_$(VariantName)_usr_share_sourcekit_lsp" Source="$(ToolchainRoot)\usr\share\sourcekit-lsp\config.schema.json" />
     </ComponentGroup>
 
-    <ComponentGroup Id="SxSSwiftRuntime">
-      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationXML" Source="$(ToolchainRoot)\usr\bin\FoundationXML\FoundationXML.dll" />
-      <File Directory="toolchain_$(VariantName)_usr_bin_swiftRegexBuilder" Source="$(ToolchainRoot)\usr\bin\swiftRegexBuilder\swiftRegexBuilder.dll" />
-    </ComponentGroup>
-
     <Feature Id="IDETools" AllowAbsent="no" Title="$(VariantProductName)">
       <ComponentGroupRef Id="clangd" />
       <ComponentGroupRef Id="lldb" />
       <ComponentGroupRef Id="sourcekitd" />
       <ComponentGroupRef Id="lsp" />
-      <ComponentGroupRef Id="SxSSwiftRuntime" />
-
       <ComponentGroupRef Id="VersionedDirectoryCleanup" />
     </Feature>
   </Package>

--- a/platforms/Windows/prt/asserts/prt.asserts.wixproj
+++ b/platforms/Windows/prt/asserts/prt.asserts.wixproj
@@ -1,0 +1,1 @@
+<Project Sdk="WixToolset.Sdk/7.0.0" />

--- a/platforms/Windows/prt/asserts/prt.asserts.wxs
+++ b/platforms/Windows/prt/asserts/prt.asserts.wxs
@@ -1,0 +1,4 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <?define VariantName = Asserts ?>
+  <?include ../prt.wxi ?>
+</Wix>

--- a/platforms/Windows/prt/noasserts/prt.noasserts.wixproj
+++ b/platforms/Windows/prt/noasserts/prt.noasserts.wixproj
@@ -1,0 +1,1 @@
+<Project Sdk="WixToolset.Sdk/7.0.0" />

--- a/platforms/Windows/prt/noasserts/prt.noasserts.wxs
+++ b/platforms/Windows/prt/noasserts/prt.noasserts.wxs
@@ -1,0 +1,4 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <?define VariantName = NoAsserts ?>
+  <?include ../prt.wxi ?>
+</Wix>

--- a/platforms/Windows/prt/prt.wxi
+++ b/platforms/Windows/prt/prt.wxi
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <?define ToolchainRoot = $(ImageRoot)\Toolchains\$(ProductVersion)+$(VariantName)?>
+  <?if $(VariantName) == Asserts?>
+    <?define VariantUpgradeCode = $(PrtAssertsUpgradeCode)?>
+    <?define VariantCabinetName = prt.asserts.cab?>
+  <?else?>
+    <?define VariantUpgradeCode = $(PrtNoAssertsUpgradeCode)?>
+    <?define VariantCabinetName = prt.noasserts.cab?>
+  <?endif?>
+  <?define VariantProductName = "!(loc.Prt_ProductName) ($(VariantName))"?>
+
+  <Package
+      Language="1033"
+      Manufacturer="!(loc.ManufacturerName)"
+      Name="$(VariantProductName)"
+      UpgradeCode="$(VariantUpgradeCode)"
+      Version="$(NonSemVerProductVersion)"
+      Scope="$(PackageScope)">
+
+    <Media Id="1" Cabinet="$(VariantCabinetName)" EmbedCab="$(ArePackageCabsEmbedded)" />
+
+    <WixVariable Id="SideBySidePackageUpgradeCode" Value="$(VariantUpgradeCode)" />
+    <FeatureGroupRef Id="SideBySideUpgradeStrategy" />
+
+    <Property Id="INSTALLBLD" Value="1" />
+    <Property Id="INSTALLCLI" Value="1" />
+    <Property Id="INSTALLDBG" Value="1" />
+    <Property Id="INSTALLIDE" Value="1" />
+
+    <DirectoryRef Id="toolchain_$(VariantName)_usr_bin">
+      <Directory Id="toolchain_$(VariantName)_usr_bin__FoundationICU" Name="_FoundationICU" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_BlocksRuntime" Name="BlocksRuntime" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_dispatch" Name="dispatch" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_Foundation" Name="Foundation" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationEssentials" Name="FoundationEssentials" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationInternationalization" Name="FoundationInternationalization" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationNetworking" Name="FoundationNetworking" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_FoundationXML" Name="FoundationXML" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_Concurrency" Name="swift_Concurrency" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_RegexParser" Name="swift_RegexParser" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swift_StringProcessing" Name="swift_StringProcessing" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftCore" Name="swiftCore" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftCRT" Name="swiftCRT" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftDispatch" Name="swiftDispatch" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftObservation" Name="swiftObservation" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftRegexBuilder" Name="swiftRegexBuilder" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftRemoteMirror" Name="swiftRemoteMirror" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftSynchronization" Name="swiftSynchronization" />
+      <Directory Id="toolchain_$(VariantName)_usr_bin_swiftWinSDK" Name="swiftWinSDK" />
+    </DirectoryRef>
+
+    <ComponentGroup Id="SxSSwiftRuntimeBase">
+      <File Directory="toolchain_$(VariantName)_usr_bin__FoundationICU" Source="$(ToolchainRoot)\usr\bin\_FoundationICU\_FoundationICU.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_BlocksRuntime" Source="$(ToolchainRoot)\usr\bin\BlocksRuntime\BlocksRuntime.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_dispatch" Source="$(ToolchainRoot)\usr\bin\dispatch\dispatch.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_Foundation" Source="$(ToolchainRoot)\usr\bin\Foundation\Foundation.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationEssentials" Source="$(ToolchainRoot)\usr\bin\FoundationEssentials\FoundationEssentials.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationInternationalization" Source="$(ToolchainRoot)\usr\bin\FoundationInternationalization\FoundationInternationalization.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swift_Concurrency" Source="$(ToolchainRoot)\usr\bin\swift_Concurrency\swift_Concurrency.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swift_RegexParser" Source="$(ToolchainRoot)\usr\bin\swift_RegexParser\swift_RegexParser.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swift_StringProcessing" Source="$(ToolchainRoot)\usr\bin\swift_StringProcessing\swift_StringProcessing.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftCore" Source="$(ToolchainRoot)\usr\bin\swiftCore\swiftCore.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftCRT" Source="$(ToolchainRoot)\usr\bin\swiftCRT\swiftCRT.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftDispatch" Source="$(ToolchainRoot)\usr\bin\swiftDispatch\swiftDispatch.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftObservation" Source="$(ToolchainRoot)\usr\bin\swiftObservation\swiftObservation.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftSynchronization" Source="$(ToolchainRoot)\usr\bin\swiftSynchronization\swiftSynchronization.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftWinSDK" Source="$(ToolchainRoot)\usr\bin\swiftWinSDK\swiftWinSDK.dll" />
+    </ComponentGroup>
+
+    <ComponentGroup Id="SxSSwiftRuntimeTools">
+      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationNetworking" Source="$(ToolchainRoot)\usr\bin\FoundationNetworking\FoundationNetworking.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_FoundationXML" Source="$(ToolchainRoot)\usr\bin\FoundationXML\FoundationXML.dll" />
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftRegexBuilder" Source="$(ToolchainRoot)\usr\bin\swiftRegexBuilder\swiftRegexBuilder.dll" />
+    </ComponentGroup>
+
+    <ComponentGroup Id="SxSSwiftRuntimeDebugging">
+      <File Directory="toolchain_$(VariantName)_usr_bin_swiftRemoteMirror" Source="$(ToolchainRoot)\usr\bin\swiftRemoteMirror\swiftRemoteMirror.dll" />
+    </ComponentGroup>
+
+    <Feature Id="SxSSwiftRuntimeBLD" AllowAbsent="yes" Display="hidden" Title="$(VariantProductName): BLD">
+      <Level Condition="INSTALLBLD = 0" Value="0" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeBase" />
+    </Feature>
+
+    <Feature Id="SxSSwiftRuntimeCLI" AllowAbsent="yes" Display="hidden" Title="$(VariantProductName): CLI">
+      <Level Condition="INSTALLCLI = 0" Value="0" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeBase" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeTools" />
+    </Feature>
+
+    <Feature Id="SxSSwiftRuntimeDBG" AllowAbsent="yes" Display="hidden" Title="$(VariantProductName): DBG">
+      <Level Condition="INSTALLDBG = 0" Value="0" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeBase" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeDebugging" />
+    </Feature>
+
+    <Feature Id="SxSSwiftRuntimeIDE" AllowAbsent="yes" Display="hidden" Title="$(VariantProductName): IDE">
+      <Level Condition="INSTALLIDE = 0" Value="0" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeBase" />
+      <ComponentGroupRef Id="SxSSwiftRuntimeTools" />
+    </Feature>
+  </Package>
+</Include>

--- a/platforms/Windows/readme.md
+++ b/platforms/Windows/readme.md
@@ -143,7 +143,7 @@ That lets you override settings in Directory.Build.props for local dev builds. F
 
 ## Toolchain variants
 
-The Swift toolchain for Windows is built in multiple variants, e.g. with LLVM assertions enabled (asserts) and disabled (noasserts). These variants contribute components to several MSI packages, including the build tools (bld), command-line tools (cli), debugging tools (dbg), and IDE integration (ide). The layout is the same in the InstallDir, but the files are different and come from different roots.
+The Swift toolchain for Windows is built in multiple variants, e.g. with LLVM assertions enabled (asserts) and disabled (noasserts). These variants contribute components to several MSI packages, including the build tools (bld), command-line tools (cli), debugging tools (dbg), IDE integration (ide), and private runtime (prt). The layout is the same in the InstallDir, but the files are different and come from different roots.
 
 To handle this without duplicating our authoring, we parametrize the WiX authoring so that the installer logic can build different MSIs for each variant that includes the correct files.
 
@@ -164,6 +164,8 @@ bld/
 Each subfolder (`asserts` and `noasserts`) contains the project file that produces an msi (`bld.asserts.msi` and `bld.noasserts.msi`). Each project includes `bld.wxi` file that has the authoring for this module. New files/components would be added in `bld.wxi` ensuring they appear in all variants.
 
 The main bundle (`installer.wxs`) includes these variants conditionally, allowing users to choose which toolchain flavor to install. This parametrized structure ensures that all supported toolchain configurations are available in a single bundle, while keeping the installer authoring organized and scalable.
+
+The PRT MSI is required whenever its corresponding toolchain variant is installed. Burn passes `INSTALLBLD`, `INSTALLCLI`, `INSTALLDBG`, and `INSTALLIDE` to select the private runtime features needed by the tool packages chosen in the bundle UI. The tool MSIs do not author private runtime assemblies themselves.
 
 The `ToolchainVariants` MSBuild property controls which variants are included in the bundle.
 
@@ -247,7 +249,7 @@ Note that these GUIDs are substituted at bind time so they skip the normal valid
 
 | Property | Description |
 | -------- | ----------- |
-| BldAssertsUpgradeCode, BldNoAssertsUpgradeCode, CliAssertsUpgradeCode, CliNoAssertsUpgradeCode, DbgAssertsUpgradeCode, DbgNoAssertsUpgradeCode, IdeAssertsUpgradeCode, IdeNoAssertsUpgradeCode, RTLUpgradeCode, WindowsPlatformUpgradeCode, AndroidPlatformUpgradeCode, PythonUpgradeCode, ResUpgradeCode | Upgrade codes for individual packages. Packages keep the same upgrade codes "forever" because MSI lets you specify version ranges for upgrades, which you can find in `shared/shared.wxs`. |
+| BldAssertsUpgradeCode, BldNoAssertsUpgradeCode, CliAssertsUpgradeCode, CliNoAssertsUpgradeCode, DbgAssertsUpgradeCode, DbgNoAssertsUpgradeCode, IdeAssertsUpgradeCode, IdeNoAssertsUpgradeCode, PrtAssertsUpgradeCode, PrtNoAssertsUpgradeCode, RTLUpgradeCode, WindowsPlatformUpgradeCode, AndroidPlatformUpgradeCode, PythonUpgradeCode, ResUpgradeCode | Upgrade codes for individual packages. Packages keep the same upgrade codes "forever" because MSI lets you specify version ranges for upgrades, which you can find in `shared/shared.wxs`. |
 | BundleUpgradeCode | Upgrade codes for the bundle. Bundles don't support upgrade version ranges, so the bundle upgrade code must change for every minor version _and_ stay the same for the entire lifetime of that minor version (e.g., v5.10.0 through v5.10.9999). You can keep the history of upgrade codes using a condition like `Condition="'$(MajorMinorProductVersion)' == '5.10'` or just replace BundleUpgradeCode when forking to a new minor version. |
 
 

--- a/platforms/Windows/shared/swift.en-us.wxl
+++ b/platforms/Windows/shared/swift.en-us.wxl
@@ -15,6 +15,7 @@
   <String Id="Ide_ProductName" Value="Swift IDE Integration Tools" />
   <String Id="IdeAsserts_ProductName" Value="Swift IDE Integration Tools (Asserts)" />
   <String Id="IdeNoAsserts_ProductName" Value="Swift IDE Integration Tools (NoAsserts)" />
+  <String Id="Prt_ProductName" Value="Swift Private Runtime" />
   <String Id="Rtl_ProductName" Value="Swift Windows Runtime" />
   <String Id="VCRuntime_ProductName_arm64" Value="Visual C++ Runtime (ARM64)" />
   <String Id="VCRuntime_ProductName_amd64" Value="Visual C++ Runtime (AMD64)" />


### PR DESCRIPTION
This introduces a new PRT MSI which has two variants (`prt.asserts.msi` and `prt.noasserts.msi`) which provides the toolchain's private SxS runtime. There is an overlap in dependencies across different sets and IDE and CLI are independent but require the same runtimes. The new MSI allows us to install the proper set of libraries for the different installed components. It also simplifies the management of the private assemblies.