### PR TITLE
Add missing header to `FoundationCShimsHeaders.wxs` 

### DIFF
--- a/platforms/Windows/platforms/FoundationCShimsHeaders.wxs
+++ b/platforms/Windows/platforms/FoundationCShimsHeaders.wxs
@@ -5,6 +5,7 @@
       <File Name="bplist_shims.h" />
       <File Name="CFUniCharBitmapData.h" />
       <File Name="CFUniCharBitmapData.inc.h" />
+      <File Name="CFUniCharBitmapDataAccess.h" />
       <File Name="filemanager_shims.h" />
       <File Name="io_shims.h" />
       <File Name="module.modulemap" />


### PR DESCRIPTION
The missing header is causing the Windows toolchain to break: https://github.com/swiftlang/swift/issues/90878 