### PR TITLE
WiX: package and distribute WinSDK.apinotes

### DIFF
--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -1708,10 +1708,11 @@
     <!-- clang modules -->
     <ComponentGroup Id="AuxiliaryFiles" Directory="SDK_usr_share">
       <File Source="$(SDKRoot)\usr\share\ucrt.modulemap" />
-      <File Source="$(SDKRoot)\usr\share\winsdk_um.modulemap" />
-      <File Source="$(SDKRoot)\usr\share\winsdk_shared.modulemap" />
       <File Source="$(SDKRoot)\usr\share\vcruntime.apinotes" />
       <File Source="$(SDKRoot)\usr\share\vcruntime.modulemap" />
+      <File Source="$(SDKRoot)\usr\share\winsdk_shared.modulemap" />
+      <File Source="$(SDKRoot)\usr\share\winsdk_um.modulemap" />
+      <File Source="$(SDKRoot)\usr\share\WinSDK.apinotes" />
     </ComponentGroup>
 
     <!-- Configuration -->


### PR DESCRIPTION
WinSDK APINotes allow us to canonically shape the imported macros now that the clang importer has the ability to reshape imported macros. This should allow us to start excising the unnecessary type casting in all user contexts.