### PR TITLE
WiX: Allow overriding SignCommand

### DIFF
--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -54,17 +54,20 @@
   </Target>
 
   <Target Name="FindSignTool" DependsOnTargets="FindWindowsSDK">
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(SignCommand)' == '' ">
       <SignToolPath Condition=" '$(SignToolPath)' == '' ">$(WindowsSDKToolsPath)</SignToolPath>
       <SignToolPath Condition=" '$(SignToolPath)' != '' AND !HasTrailingSlash('$(SignToolPath)') ">$(SignToolPath)\</SignToolPath>
       <VerboseFlag Condition=" '$(SignToolVerbose)' == 'true' ">/v </VerboseFlag>
       <VerboseFlag Condition=" '$(SignToolVerbose)' != 'true' "></VerboseFlag>
-
-      <SignCommand>"$(SignToolPath)signtool.exe" sign $(VerboseFlag)/tr http://timestamp.digicert.com /fd sha256 /td sha256 /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" </SignCommand>
     </PropertyGroup>
 
-    <Error Condition=" '$(SignToolPath)' == '' OR !Exists('$(SignToolPath)signtool.exe') "
+    <Error Condition=" '$(SignCommand)' == '' AND ('$(SignToolPath)' == '' OR !Exists('$(SignToolPath)signtool.exe')) "
            Text="Unable to locate signtool.exe. Set SignToolPath to the Windows SDK bin directory." />
+
+    <!-- Fallback if `SignCommand` isn't overridden -->
+    <PropertyGroup Condition=" '$(SignCommand)' == '' ">
+      <SignCommand>"$(SignToolPath)signtool.exe" sign $(VerboseFlag)/tr http://timestamp.digicert.com /fd sha256 /td sha256 /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" </SignCommand>
+    </PropertyGroup>
   </Target>
 
   <Target Name="FindWindowsSDKTools" DependsOnTargets="FindWindowsSDK">

--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -54,14 +54,14 @@
   </Target>
 
   <Target Name="FindSignTool" DependsOnTargets="FindWindowsSDK">
-    <PropertyGroup Condition=" '$(SignCommand)' == '' ">
+    <PropertyGroup>
       <SignToolPath Condition=" '$(SignToolPath)' == '' ">$(WindowsSDKToolsPath)</SignToolPath>
       <SignToolPath Condition=" '$(SignToolPath)' != '' AND !HasTrailingSlash('$(SignToolPath)') ">$(SignToolPath)\</SignToolPath>
       <VerboseFlag Condition=" '$(SignToolVerbose)' == 'true' ">/v </VerboseFlag>
       <VerboseFlag Condition=" '$(SignToolVerbose)' != 'true' "></VerboseFlag>
     </PropertyGroup>
 
-    <Error Condition=" '$(SignCommand)' == '' AND ('$(SignToolPath)' == '' OR !Exists('$(SignToolPath)signtool.exe')) "
+    <Error Condition=" '$(SignCommand)' == '' AND !Exists('$(SignToolPath)signtool.exe') "
            Text="Unable to locate signtool.exe. Set SignToolPath to the Windows SDK bin directory." />
 
     <!-- Fallback if `SignCommand` isn't overridden -->


### PR DESCRIPTION
This change allows users to pass in a `SignCommand` property to override "vanilla" signtool.exe signing (for example, to use Azure Key Vault which requires using AzureSignTool instead of signtool.exe)