### PR TITLE
WiX: Declare SignCommand as a local property

### DIFF
--- a/platforms/Windows/WiXCodeSigning.targets
+++ b/platforms/Windows/WiXCodeSigning.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="SignCommand">
   <PropertyGroup>
     <SignOutput Condition=" '$(SignOutput)' == '' ">false</SignOutput>
     <SignOutput>$(SignOutput)</SignOutput>


### PR DESCRIPTION
This allows our fallback to work even if we're invoked with -p:SignCommand=''

As a global property, even though it's set to the empty string, our fallback wouldn't be able to replace the value.