### PR TITLE
WiX: add new modulemap files to the manifest

### DIFF
--- a/platforms/Windows/platforms/windows/windows.wxs
+++ b/platforms/Windows/platforms/windows/windows.wxs
@@ -1755,9 +1755,13 @@
 
     <!-- clang modules -->
     <ComponentGroup Id="AuxiliaryFiles" Directory="SDK_usr_share">
+      <File Source="$(SDKRoot)\usr\share\SwiftUCRT.h" />
+      <File Source="$(SDKRoot)\usr\share\SwiftWinRT.h" />
       <File Source="$(SDKRoot)\usr\share\ucrt.modulemap" />
       <File Source="$(SDKRoot)\usr\share\vcruntime.apinotes" />
       <File Source="$(SDKRoot)\usr\share\vcruntime.modulemap" />
+      <File Source="$(SDKRoot)\usr\share\winrt.modulemap" />
+      <File Source="$(SDKRoot)\usr\share\winsdk.modulemap" />
       <File Source="$(SDKRoot)\usr\share\winsdk_shared.modulemap" />
       <File Source="$(SDKRoot)\usr\share\winsdk_um.modulemap" />
       <File Source="$(SDKRoot)\usr\share\WinSDK.apinotes" />


### PR DESCRIPTION
The WinSDK module restructuring has introduced some new files which need to be enumerated for distribution.